### PR TITLE
feat: add `Visitor` & 'VisitorMut' to simply `ScalarExpression` visit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,6 +1329,7 @@ dependencies = [
  "petgraph",
  "pgwire",
  "pprof",
+ "recursive",
  "regex",
  "rocksdb",
  "rust_decimal",
@@ -1898,6 +1899,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,6 +2036,26 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "recursive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
+dependencies = [
+ "recursive-proc-macro-impl",
+ "stacker",
+]
+
+[[package]]
+name = "recursive-proc-macro-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
+dependencies = [
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2464,6 +2494,19 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "str_stack"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ ordered-float         = { version = "4", features = ["serde"] }
 paste                 = { version = "1" }
 parking_lot           = { version = "0.12", features = ["arc_lock"] }
 petgraph              = { version = "0.6" }
+recursive             = { version = "0.1" }
 regex                 = { version = "1" }
 rocksdb               = { version = "0.22" }
 rust_decimal          = { version = "1" }

--- a/src/binder/insert.rs
+++ b/src/binder/insert.rs
@@ -1,5 +1,7 @@
 use crate::binder::{lower_case_name, Binder};
 use crate::errors::DatabaseError;
+use crate::expression::simplify::ConstantCalculator;
+use crate::expression::visitor_mut::VisitorMut;
 use crate::expression::ScalarExpression;
 use crate::planner::operator::insert::InsertOperator;
 use crate::planner::operator::values::ValuesOperator;
@@ -69,8 +71,8 @@ impl<T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'_, '_, T, A>
 
             for (i, expr) in expr_row.iter().enumerate() {
                 let mut expression = self.bind_expr(expr)?;
-
-                expression.constant_calculation()?;
+                
+                ConstantCalculator.visit(&mut expression)?;
                 match expression {
                     ScalarExpression::Constant(value) => {
                         let ty = schema_ref[i].datatype();

--- a/src/binder/select.rs
+++ b/src/binder/select.rs
@@ -33,7 +33,6 @@ use crate::planner::{Childrens, LogicalPlan, SchemaOutput};
 use crate::storage::Transaction;
 use crate::types::tuple::{Schema, SchemaRef};
 use crate::types::value::Utf8Type;
-use crate::types::LogicalType::Char;
 use crate::types::{ColumnId, LogicalType};
 use itertools::Itertools;
 use sqlparser::ast::{

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -3,15 +3,17 @@ use crate::catalog::{ColumnCatalog, ColumnDesc, ColumnRef};
 use crate::errors::DatabaseError;
 use crate::expression::function::scala::ScalarFunction;
 use crate::expression::function::table::TableFunction;
+use crate::expression::visitor::{walk_expr, Visitor};
+use crate::expression::visitor_mut::{walk_mut_expr, VisitorMut};
 use crate::types::evaluator::{BinaryEvaluatorBox, EvaluatorFactory, UnaryEvaluatorBox};
 use crate::types::value::DataValue;
 use crate::types::LogicalType;
 use itertools::Itertools;
 use kite_sql_serde_macros::ReferenceSerialization;
-use sqlparser::ast::TrimWhereField;
 use sqlparser::ast::{
     BinaryOperator as SqlBinaryOperator, CharLengthUnits, UnaryOperator as SqlUnaryOperator,
 };
+use sqlparser::ast::TrimWhereField;
 use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
 use std::{fmt, mem};
@@ -21,6 +23,8 @@ mod evaluator;
 pub mod function;
 pub mod range_detacher;
 pub mod simplify;
+pub mod visitor;
+pub mod visitor_mut;
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, ReferenceSerialization)]
 pub enum AliasType {
@@ -129,6 +133,130 @@ pub enum ScalarExpression {
     },
 }
 
+#[derive(Clone)]
+pub struct TryReference<'a> {
+    output_exprs: &'a [ScalarExpression],
+}
+
+impl<'a> VisitorMut<'a> for TryReference<'a> {
+    fn visit(&mut self, expr: &'a mut ScalarExpression) -> Result<(), DatabaseError> {
+        let mut clone_expr = mem::replace(expr, ScalarExpression::Empty);
+        walk_mut_expr(&mut self.clone(), &mut clone_expr)?;
+
+        let fn_output_column = |expr: &ScalarExpression| expr.output_column();
+        let self_column = fn_output_column(&clone_expr);
+
+        *expr = if let Some((pos, _)) = self
+            .output_exprs
+            .iter()
+            .find_position(|expr| self_column.summary() == fn_output_column(expr).summary())
+        {
+            ScalarExpression::Reference {
+                expr: Box::new(clone_expr),
+                pos,
+            }
+        } else {
+            clone_expr
+        };
+        Ok(())
+    }
+}
+
+impl<'a> TryReference<'a> {
+    pub fn new(output_exprs: &'a [ScalarExpression]) -> TryReference<'a> {
+        TryReference { output_exprs }
+    }
+}
+
+pub struct BindEvaluator;
+
+impl VisitorMut<'_> for BindEvaluator {
+    fn visit_unary(
+        &mut self,
+        op: &'_ mut UnaryOperator,
+        expr: &'_ mut ScalarExpression,
+        evaluator: &'_ mut Option<UnaryEvaluatorBox>,
+        _ty: &'_ mut LogicalType,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)?;
+
+        let ty = expr.return_type();
+        if ty.is_unsigned_numeric() {
+            *expr = ScalarExpression::TypeCast {
+                expr: Box::new(mem::replace(expr, ScalarExpression::Empty)),
+                ty: match ty {
+                    LogicalType::UTinyint => LogicalType::Tinyint,
+                    LogicalType::USmallint => LogicalType::Smallint,
+                    LogicalType::UInteger => LogicalType::Integer,
+                    LogicalType::UBigint => LogicalType::Bigint,
+                    _ => unreachable!(),
+                },
+            }
+        }
+        *evaluator = Some(EvaluatorFactory::unary_create(ty, *op)?);
+
+        Ok(())
+    }
+
+    fn visit_binary(
+        &mut self,
+        op: &'_ mut BinaryOperator,
+        left_expr: &'_ mut ScalarExpression,
+        right_expr: &'_ mut ScalarExpression,
+        evaluator: &'_ mut Option<BinaryEvaluatorBox>,
+        _ty: &'_ mut LogicalType,
+    ) -> Result<(), DatabaseError> {
+        self.visit(left_expr)?;
+        self.visit(right_expr)?;
+
+        let ty =
+            LogicalType::max_logical_type(&left_expr.return_type(), &right_expr.return_type())?;
+        let fn_cast = |expr: &mut ScalarExpression, ty: LogicalType| {
+            if expr.return_type() != ty {
+                *expr = ScalarExpression::TypeCast {
+                    expr: Box::new(mem::replace(expr, ScalarExpression::Empty)),
+                    ty,
+                }
+            }
+        };
+        fn_cast(left_expr, ty.clone());
+        fn_cast(right_expr, ty.clone());
+
+        *evaluator = Some(EvaluatorFactory::binary_create(ty, *op)?);
+
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+pub struct HasCountStar {
+    pub value: bool,
+}
+
+impl Visitor<'_> for HasCountStar {
+    fn visit_agg(
+        &mut self,
+        _distinct: bool,
+        _kind: &'_ AggKind,
+        args: &'_ [ScalarExpression],
+        _ty: &'_ LogicalType,
+    ) -> Result<(), DatabaseError> {
+        if args.len() == 1 {
+            if let ScalarExpression::Constant(value) = &args[0] {
+                self.value = matches!(value.utf8(), Some("*"));
+            }
+        }
+        Ok(())
+    }
+
+    fn visit(&mut self, expr: &'_ ScalarExpression) -> Result<(), DatabaseError> {
+        if !self.value {
+            walk_expr(self, expr)?;
+        }
+        Ok(())
+    }
+}
+
 impl ScalarExpression {
     pub fn unpack_alias(self) -> ScalarExpression {
         if let ScalarExpression::Alias {
@@ -155,419 +283,6 @@ impl ScalarExpression {
             expr.unpack_alias_ref()
         } else {
             self
-        }
-    }
-
-    pub fn try_reference(&mut self, output_exprs: &[ScalarExpression]) {
-        let fn_output_column = |expr: &ScalarExpression| expr.output_column();
-        let self_column = fn_output_column(self);
-        if let Some((pos, _)) = output_exprs
-            .iter()
-            .find_position(|expr| self_column.summary() == fn_output_column(expr).summary())
-        {
-            let expr = Box::new(mem::replace(self, ScalarExpression::Empty));
-            *self = ScalarExpression::Reference { expr, pos };
-            return;
-        }
-
-        match self {
-            ScalarExpression::Alias { expr, .. } => {
-                expr.try_reference(output_exprs);
-            }
-            ScalarExpression::TypeCast { expr, .. } => {
-                expr.try_reference(output_exprs);
-            }
-            ScalarExpression::IsNull { expr, .. } => {
-                expr.try_reference(output_exprs);
-            }
-            ScalarExpression::Unary { expr, .. } => {
-                expr.try_reference(output_exprs);
-            }
-            ScalarExpression::Binary {
-                left_expr,
-                right_expr,
-                ..
-            } => {
-                left_expr.try_reference(output_exprs);
-                right_expr.try_reference(output_exprs);
-            }
-            ScalarExpression::AggCall { args, .. }
-            | ScalarExpression::Coalesce { exprs: args, .. }
-            | ScalarExpression::Tuple(args) => {
-                for arg in args {
-                    arg.try_reference(output_exprs);
-                }
-            }
-            ScalarExpression::In { expr, args, .. } => {
-                expr.try_reference(output_exprs);
-                for arg in args {
-                    arg.try_reference(output_exprs);
-                }
-            }
-            ScalarExpression::Between {
-                expr,
-                left_expr,
-                right_expr,
-                ..
-            } => {
-                expr.try_reference(output_exprs);
-                left_expr.try_reference(output_exprs);
-                right_expr.try_reference(output_exprs);
-            }
-            ScalarExpression::SubString {
-                expr,
-                for_expr,
-                from_expr,
-            } => {
-                expr.try_reference(output_exprs);
-                if let Some(expr) = for_expr {
-                    expr.try_reference(output_exprs);
-                }
-                if let Some(expr) = from_expr {
-                    expr.try_reference(output_exprs);
-                }
-            }
-            ScalarExpression::Position { expr, in_expr } => {
-                expr.try_reference(output_exprs);
-                in_expr.try_reference(output_exprs);
-            }
-            ScalarExpression::Trim {
-                expr,
-                trim_what_expr,
-                ..
-            } => {
-                expr.try_reference(output_exprs);
-                if let Some(trim_what_expr) = trim_what_expr {
-                    trim_what_expr.try_reference(output_exprs);
-                }
-            }
-            ScalarExpression::Empty => unreachable!(),
-            ScalarExpression::Constant(_)
-            | ScalarExpression::ColumnRef(_)
-            | ScalarExpression::Reference { .. } => (),
-            ScalarExpression::ScalaFunction(function) => {
-                for expr in function.args.iter_mut() {
-                    expr.try_reference(output_exprs);
-                }
-            }
-            ScalarExpression::TableFunction(function) => {
-                for expr in function.args.iter_mut() {
-                    expr.try_reference(output_exprs);
-                }
-            }
-            ScalarExpression::If {
-                condition,
-                left_expr,
-                right_expr,
-                ..
-            } => {
-                condition.try_reference(output_exprs);
-                left_expr.try_reference(output_exprs);
-                right_expr.try_reference(output_exprs);
-            }
-            ScalarExpression::IfNull {
-                left_expr,
-                right_expr,
-                ..
-            }
-            | ScalarExpression::NullIf {
-                left_expr,
-                right_expr,
-                ..
-            } => {
-                left_expr.try_reference(output_exprs);
-                right_expr.try_reference(output_exprs);
-            }
-            ScalarExpression::CaseWhen {
-                operand_expr,
-                expr_pairs,
-                else_expr,
-                ..
-            } => {
-                if let Some(expr) = operand_expr {
-                    expr.try_reference(output_exprs);
-                }
-                for (expr_1, expr_2) in expr_pairs {
-                    expr_1.try_reference(output_exprs);
-                    expr_2.try_reference(output_exprs);
-                }
-                if let Some(expr) = else_expr {
-                    expr.try_reference(output_exprs);
-                }
-            }
-        }
-    }
-
-    pub fn bind_evaluator(&mut self) -> Result<(), DatabaseError> {
-        match self {
-            ScalarExpression::Binary {
-                left_expr,
-                right_expr,
-                op,
-                evaluator,
-                ..
-            } => {
-                left_expr.bind_evaluator()?;
-                right_expr.bind_evaluator()?;
-
-                let ty = LogicalType::max_logical_type(
-                    &left_expr.return_type(),
-                    &right_expr.return_type(),
-                )?;
-                let fn_cast = |expr: &mut ScalarExpression, ty: LogicalType| {
-                    if expr.return_type() != ty {
-                        *expr = ScalarExpression::TypeCast {
-                            expr: Box::new(mem::replace(expr, ScalarExpression::Empty)),
-                            ty,
-                        }
-                    }
-                };
-                fn_cast(left_expr, ty.clone());
-                fn_cast(right_expr, ty.clone());
-
-                *evaluator = Some(EvaluatorFactory::binary_create(ty, *op)?);
-            }
-            ScalarExpression::Unary {
-                expr,
-                op,
-                evaluator,
-                ..
-            } => {
-                expr.bind_evaluator()?;
-
-                let ty = expr.return_type();
-                if ty.is_unsigned_numeric() {
-                    *expr.as_mut() = ScalarExpression::TypeCast {
-                        expr: Box::new(mem::replace(expr, ScalarExpression::Empty)),
-                        ty: match ty {
-                            LogicalType::UTinyint => LogicalType::Tinyint,
-                            LogicalType::USmallint => LogicalType::Smallint,
-                            LogicalType::UInteger => LogicalType::Integer,
-                            LogicalType::UBigint => LogicalType::Bigint,
-                            _ => unreachable!(),
-                        },
-                    }
-                }
-                *evaluator = Some(EvaluatorFactory::unary_create(ty, *op)?);
-            }
-            ScalarExpression::Alias { expr, .. } => {
-                expr.bind_evaluator()?;
-            }
-            ScalarExpression::TypeCast { expr, .. } => {
-                expr.bind_evaluator()?;
-            }
-            ScalarExpression::IsNull { expr, .. } => {
-                expr.bind_evaluator()?;
-            }
-            ScalarExpression::AggCall { args, .. }
-            | ScalarExpression::Coalesce { exprs: args, .. }
-            | ScalarExpression::Tuple(args) => {
-                for arg in args {
-                    arg.bind_evaluator()?;
-                }
-            }
-            ScalarExpression::In { expr, args, .. } => {
-                expr.bind_evaluator()?;
-                for arg in args {
-                    arg.bind_evaluator()?;
-                }
-            }
-            ScalarExpression::Between {
-                expr,
-                left_expr,
-                right_expr,
-                ..
-            } => {
-                expr.bind_evaluator()?;
-                left_expr.bind_evaluator()?;
-                right_expr.bind_evaluator()?;
-            }
-            ScalarExpression::SubString {
-                expr,
-                for_expr,
-                from_expr,
-            } => {
-                expr.bind_evaluator()?;
-                if let Some(expr) = for_expr {
-                    expr.bind_evaluator()?;
-                }
-                if let Some(expr) = from_expr {
-                    expr.bind_evaluator()?;
-                }
-            }
-            ScalarExpression::Position { expr, in_expr } => {
-                expr.bind_evaluator()?;
-                in_expr.bind_evaluator()?;
-            }
-            ScalarExpression::Trim {
-                expr,
-                trim_what_expr,
-                ..
-            } => {
-                expr.bind_evaluator()?;
-                if let Some(trim_what_expr) = trim_what_expr {
-                    trim_what_expr.bind_evaluator()?;
-                }
-            }
-            ScalarExpression::Empty => unreachable!(),
-            ScalarExpression::Constant(_)
-            | ScalarExpression::ColumnRef(_)
-            | ScalarExpression::Reference { .. } => (),
-            ScalarExpression::ScalaFunction(function) => {
-                for expr in function.args.iter_mut() {
-                    expr.bind_evaluator()?;
-                }
-            }
-            ScalarExpression::TableFunction(function) => {
-                for expr in function.args.iter_mut() {
-                    expr.bind_evaluator()?;
-                }
-            }
-            ScalarExpression::If {
-                condition,
-                left_expr,
-                right_expr,
-                ..
-            } => {
-                condition.bind_evaluator()?;
-                left_expr.bind_evaluator()?;
-                right_expr.bind_evaluator()?;
-            }
-            ScalarExpression::IfNull {
-                left_expr,
-                right_expr,
-                ..
-            }
-            | ScalarExpression::NullIf {
-                left_expr,
-                right_expr,
-                ..
-            } => {
-                left_expr.bind_evaluator()?;
-                right_expr.bind_evaluator()?;
-            }
-            ScalarExpression::CaseWhen {
-                operand_expr,
-                expr_pairs,
-                else_expr,
-                ..
-            } => {
-                if let Some(expr) = operand_expr {
-                    expr.bind_evaluator()?;
-                }
-                for (expr_1, expr_2) in expr_pairs {
-                    expr_1.bind_evaluator()?;
-                    expr_2.bind_evaluator()?;
-                }
-                if let Some(expr) = else_expr {
-                    expr.bind_evaluator()?;
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    pub fn has_count_star(&self) -> bool {
-        match self {
-            ScalarExpression::Alias { expr, .. } => expr.has_count_star(),
-            ScalarExpression::TypeCast { expr, .. } => expr.has_count_star(),
-            ScalarExpression::IsNull { expr, .. } => expr.has_count_star(),
-            ScalarExpression::Unary { expr, .. } => expr.has_count_star(),
-            ScalarExpression::Binary {
-                left_expr,
-                right_expr,
-                ..
-            } => left_expr.has_count_star() || right_expr.has_count_star(),
-            ScalarExpression::AggCall { args, .. } => {
-                if args.len() == 1 {
-                    if let ScalarExpression::Constant(value) = &args[0] {
-                        return matches!(value.utf8(), Some("*"));
-                    }
-                }
-                args.iter().any(Self::has_count_star)
-            }
-            ScalarExpression::ScalaFunction(ScalarFunction { args, .. })
-            | ScalarExpression::Coalesce { exprs: args, .. } => {
-                args.iter().any(Self::has_count_star)
-            }
-            ScalarExpression::TableFunction(_) => unreachable!(),
-            ScalarExpression::Constant(_) | ScalarExpression::ColumnRef(_) => false,
-            ScalarExpression::In { expr, args, .. } => {
-                expr.has_count_star() || args.iter().any(Self::has_count_star)
-            }
-            ScalarExpression::Between {
-                expr,
-                left_expr,
-                right_expr,
-                ..
-            } => expr.has_count_star() || left_expr.has_count_star() || right_expr.has_count_star(),
-            ScalarExpression::SubString {
-                expr,
-                from_expr,
-                for_expr,
-            } => {
-                expr.has_count_star()
-                    || matches!(
-                        from_expr.as_ref().map(|expr| expr.has_count_star()),
-                        Some(true)
-                    )
-                    || matches!(
-                        for_expr.as_ref().map(|expr| expr.has_count_star()),
-                        Some(true)
-                    )
-            }
-            ScalarExpression::Position { expr, in_expr } => {
-                expr.has_count_star() || in_expr.has_count_star()
-            }
-            ScalarExpression::Trim {
-                expr,
-                trim_what_expr,
-                ..
-            } => {
-                expr.has_count_star()
-                    || trim_what_expr.as_ref().map(|expr| expr.has_count_star()) == Some(true)
-            }
-            ScalarExpression::Empty => unreachable!(),
-            ScalarExpression::Reference { expr, .. } => expr.has_count_star(),
-            ScalarExpression::Tuple(args) => args.iter().any(Self::has_count_star),
-            ScalarExpression::If {
-                condition,
-                left_expr,
-                right_expr,
-                ..
-            } => {
-                condition.has_count_star()
-                    || left_expr.has_count_star()
-                    || right_expr.has_count_star()
-            }
-            ScalarExpression::IfNull {
-                left_expr,
-                right_expr,
-                ..
-            }
-            | ScalarExpression::NullIf {
-                left_expr,
-                right_expr,
-                ..
-            } => left_expr.has_count_star() || right_expr.has_count_star(),
-            ScalarExpression::CaseWhen {
-                operand_expr,
-                expr_pairs,
-                else_expr,
-                ..
-            } => {
-                matches!(
-                    operand_expr.as_ref().map(|expr| expr.has_count_star()),
-                    Some(true)
-                ) || expr_pairs
-                    .iter()
-                    .any(|(expr_1, expr_2)| expr_1.has_count_star() || expr_2.has_count_star())
-                    || matches!(
-                        else_expr.as_ref().map(|expr| expr.has_count_star()),
-                        Some(true)
-                    )
-            }
         }
     }
 

--- a/src/expression/visitor.rs
+++ b/src/expression/visitor.rs
@@ -1,0 +1,340 @@
+use crate::catalog::ColumnRef;
+use crate::errors::DatabaseError;
+use crate::expression::agg::AggKind;
+use crate::expression::function::scala::ScalarFunction;
+use crate::expression::function::table::TableFunction;
+use crate::expression::{AliasType, BinaryOperator, ScalarExpression, UnaryOperator};
+use crate::types::evaluator::{BinaryEvaluatorBox, UnaryEvaluatorBox};
+use crate::types::value::DataValue;
+use crate::types::LogicalType;
+use sqlparser::ast::TrimWhereField;
+
+pub trait Visitor<'a>: Sized {
+    fn visit(&mut self, expr: &'a ScalarExpression) -> Result<(), DatabaseError> {
+        walk_expr(self, expr)
+    }
+
+    fn visit_constant(&mut self, _value: &'a DataValue) -> Result<(), DatabaseError> {
+        Ok(())
+    }
+
+    fn visit_column_ref(&mut self, _column: &'a ColumnRef) -> Result<(), DatabaseError> {
+        Ok(())
+    }
+
+    fn visit_alias(
+        &mut self,
+        expr: &'a ScalarExpression,
+        _ty: &'a AliasType,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)
+    }
+
+    fn visit_type_cast(
+        &mut self,
+        expr: &'a ScalarExpression,
+        _ty: &'a LogicalType,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)
+    }
+
+    fn visit_is_null(
+        &mut self,
+        _negated: bool,
+        expr: &'a ScalarExpression,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)
+    }
+
+    fn visit_unary(
+        &mut self,
+        _op: &'a UnaryOperator,
+        expr: &'a ScalarExpression,
+        _evaluator: Option<&'a UnaryEvaluatorBox>,
+        _ty: &'a LogicalType,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)
+    }
+
+    fn visit_binary(
+        &mut self,
+        _op: &'a BinaryOperator,
+        left_expr: &'a ScalarExpression,
+        right_expr: &'a ScalarExpression,
+        _evaluator: Option<&'a BinaryEvaluatorBox>,
+        _ty: &'a LogicalType,
+    ) -> Result<(), DatabaseError> {
+        self.visit(left_expr)?;
+        self.visit(right_expr)
+    }
+
+    fn visit_agg(
+        &mut self,
+        _distinct: bool,
+        _kind: &'a AggKind,
+        args: &'a [ScalarExpression],
+        _ty: &'a LogicalType,
+    ) -> Result<(), DatabaseError> {
+        for arg in args {
+            self.visit(arg)?;
+        }
+        Ok(())
+    }
+
+    fn visit_in(
+        &mut self,
+        _negated: bool,
+        expr: &'a ScalarExpression,
+        args: &'a [ScalarExpression],
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)?;
+        for arg in args {
+            self.visit(arg)?;
+        }
+        Ok(())
+    }
+
+    fn visit_between(
+        &mut self,
+        _negated: bool,
+        expr: &'a ScalarExpression,
+        left_expr: &'a ScalarExpression,
+        right_expr: &'a ScalarExpression,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)?;
+        self.visit(left_expr)?;
+        self.visit(right_expr)
+    }
+
+    fn visit_substring(
+        &mut self,
+        expr: &'a ScalarExpression,
+        for_expr: Option<&'a ScalarExpression>,
+        from_expr: Option<&'a ScalarExpression>,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)?;
+        if let Some(for_expr) = for_expr {
+            self.visit(for_expr)?;
+        }
+        if let Some(from_expr) = from_expr {
+            self.visit(from_expr)?;
+        }
+        Ok(())
+    }
+
+    fn visit_position(
+        &mut self,
+        expr: &'a ScalarExpression,
+        in_expr: &'a ScalarExpression,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)?;
+        self.visit(in_expr)
+    }
+
+    fn visit_trim(
+        &mut self,
+        expr: &'a ScalarExpression,
+        trim_what_expr: Option<&'a ScalarExpression>,
+        _trim_where: Option<&'a TrimWhereField>,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)?;
+        if let Some(trim_what_expr) = trim_what_expr {
+            self.visit(trim_what_expr)?;
+        }
+        Ok(())
+    }
+
+    fn visit_empty(&mut self) -> Result<(), DatabaseError> {
+        Ok(())
+    }
+
+    fn visit_reference(
+        &mut self,
+        expr: &'a ScalarExpression,
+        _pos: usize,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)
+    }
+
+    fn visit_tuple(&mut self, exprs: &'a [ScalarExpression]) -> Result<(), DatabaseError> {
+        for expr in exprs {
+            self.visit(expr)?;
+        }
+        Ok(())
+    }
+
+    fn visit_scala_function(
+        &mut self,
+        scalar_function: &'a ScalarFunction,
+    ) -> Result<(), DatabaseError> {
+        for arg in &scalar_function.args {
+            self.visit(arg)?;
+        }
+        Ok(())
+    }
+
+    fn visit_table_function(
+        &mut self,
+        table_function: &'a TableFunction,
+    ) -> Result<(), DatabaseError> {
+        for arg in &table_function.args {
+            self.visit(arg)?;
+        }
+        Ok(())
+    }
+
+    fn visit_if(
+        &mut self,
+        condition: &'a ScalarExpression,
+        left_expr: &'a ScalarExpression,
+        right_expr: &'a ScalarExpression,
+        _ty: &'a LogicalType,
+    ) -> Result<(), DatabaseError> {
+        self.visit(condition)?;
+        self.visit(left_expr)?;
+        self.visit(right_expr)
+    }
+
+    fn visit_if_null(
+        &mut self,
+        left_expr: &'a ScalarExpression,
+        right_expr: &'a ScalarExpression,
+        _ty: &'a LogicalType,
+    ) -> Result<(), DatabaseError> {
+        self.visit(left_expr)?;
+        self.visit(right_expr)
+    }
+
+    fn visit_null_if(
+        &mut self,
+        left_expr: &'a ScalarExpression,
+        right_expr: &'a ScalarExpression,
+        _ty: &'a LogicalType,
+    ) -> Result<(), DatabaseError> {
+        self.visit(left_expr)?;
+        self.visit(right_expr)
+    }
+
+    fn visit_coalesce(
+        &mut self,
+        exprs: &'a [ScalarExpression],
+        _ty: &'a LogicalType,
+    ) -> Result<(), DatabaseError> {
+        for expr in exprs {
+            self.visit(expr)?;
+        }
+        Ok(())
+    }
+
+    fn visit_case_when(
+        &mut self,
+        operand_expr: Option<&'a ScalarExpression>,
+        expr_pairs: &'a [(ScalarExpression, ScalarExpression)],
+        else_expr: Option<&'a ScalarExpression>,
+        _ty: &'a LogicalType,
+    ) -> Result<(), DatabaseError> {
+        if let Some(operand_expr) = operand_expr {
+            self.visit(operand_expr)?;
+        }
+        for (left_expr, right_expr) in expr_pairs {
+            self.visit(left_expr)?;
+            self.visit(right_expr)?;
+        }
+        if let Some(else_expr) = else_expr {
+            self.visit(else_expr)?;
+        }
+        Ok(())
+    }
+}
+
+#[recursive::recursive]
+pub fn walk_expr<'a, V: Visitor<'a>>(
+    visitor: &mut V,
+    expr: &'a ScalarExpression,
+) -> Result<(), DatabaseError> {
+    match expr {
+        ScalarExpression::Constant(value) => visitor.visit_constant(value),
+        ScalarExpression::ColumnRef(column_ref) => visitor.visit_column_ref(column_ref),
+        ScalarExpression::Alias { expr, alias } => visitor.visit_alias(expr, alias),
+        ScalarExpression::TypeCast { expr, ty } => visitor.visit_type_cast(expr, ty),
+        ScalarExpression::IsNull { negated, expr } => visitor.visit_is_null(*negated, expr),
+        ScalarExpression::Unary {
+            op,
+            expr,
+            evaluator,
+            ty,
+        } => visitor.visit_unary(op, expr, evaluator.as_ref(), ty),
+        ScalarExpression::Binary {
+            op,
+            left_expr,
+            right_expr,
+            evaluator,
+            ty,
+        } => visitor.visit_binary(op, left_expr, right_expr, evaluator.as_ref(), ty),
+        ScalarExpression::AggCall {
+            distinct,
+            kind,
+            args,
+            ty,
+        } => visitor.visit_agg(*distinct, kind, args, ty),
+        ScalarExpression::In {
+            negated,
+            expr,
+            args,
+        } => visitor.visit_in(*negated, expr, args),
+        ScalarExpression::Between {
+            negated,
+            expr,
+            left_expr,
+            right_expr,
+        } => visitor.visit_between(*negated, expr, left_expr, right_expr),
+        ScalarExpression::SubString {
+            expr,
+            for_expr,
+            from_expr,
+        } => visitor.visit_substring(expr, for_expr.as_deref(), from_expr.as_deref()),
+        ScalarExpression::Position { expr, in_expr } => visitor.visit_position(expr, in_expr),
+        ScalarExpression::Trim {
+            expr,
+            trim_what_expr,
+            trim_where,
+        } => visitor.visit_trim(expr, trim_what_expr.as_deref(), trim_where.as_ref()),
+        ScalarExpression::Empty => visitor.visit_empty(),
+        ScalarExpression::Reference { expr, pos } => visitor.visit_reference(expr, *pos),
+        ScalarExpression::Tuple(exprs) => visitor.visit_tuple(exprs),
+        ScalarExpression::ScalaFunction(scalar_function) => {
+            visitor.visit_scala_function(scalar_function)
+        }
+        ScalarExpression::TableFunction(table_function) => {
+            visitor.visit_table_function(table_function)
+        }
+        ScalarExpression::If {
+            condition,
+            left_expr,
+            right_expr,
+            ty,
+        } => visitor.visit_if(condition, left_expr, right_expr, ty),
+        ScalarExpression::IfNull {
+            left_expr,
+            right_expr,
+            ty,
+        } => visitor.visit_if_null(left_expr, right_expr, ty),
+        ScalarExpression::NullIf {
+            left_expr,
+            right_expr,
+            ty,
+        } => visitor.visit_null_if(left_expr, right_expr, ty),
+        ScalarExpression::Coalesce { exprs, ty } => visitor.visit_coalesce(exprs, ty),
+        ScalarExpression::CaseWhen {
+            operand_expr,
+            expr_pairs,
+            else_expr,
+            ty,
+        } => visitor.visit_case_when(
+            operand_expr.as_deref(),
+            expr_pairs,
+            else_expr.as_deref(),
+            ty,
+        ),
+    }
+}

--- a/src/expression/visitor_mut.rs
+++ b/src/expression/visitor_mut.rs
@@ -1,0 +1,335 @@
+use crate::catalog::ColumnRef;
+use crate::errors::DatabaseError;
+use crate::expression::agg::AggKind;
+use crate::expression::function::scala::ScalarFunction;
+use crate::expression::function::table::TableFunction;
+use crate::expression::{AliasType, BinaryOperator, ScalarExpression, UnaryOperator};
+use crate::types::evaluator::{BinaryEvaluatorBox, UnaryEvaluatorBox};
+use crate::types::value::DataValue;
+use crate::types::LogicalType;
+use sqlparser::ast::TrimWhereField;
+
+pub trait VisitorMut<'a>: Sized {
+    fn visit(&mut self, expr: &'a mut ScalarExpression) -> Result<(), DatabaseError> {
+        walk_mut_expr(self, expr)
+    }
+
+    fn visit_constant(&mut self, _value: &'a mut DataValue) -> Result<(), DatabaseError> {
+        Ok(())
+    }
+
+    fn visit_column_ref(&mut self, _column: &'a mut ColumnRef) -> Result<(), DatabaseError> {
+        Ok(())
+    }
+
+    fn visit_alias(
+        &mut self,
+        expr: &'a mut ScalarExpression,
+        _ty: &'a mut AliasType,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)
+    }
+
+    fn visit_type_cast(
+        &mut self,
+        expr: &'a mut ScalarExpression,
+        _ty: &'a mut LogicalType,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)
+    }
+
+    fn visit_is_null(
+        &mut self,
+        _negated: bool,
+        expr: &'a mut ScalarExpression,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)
+    }
+
+    fn visit_unary(
+        &mut self,
+        _op: &'a mut UnaryOperator,
+        expr: &'a mut ScalarExpression,
+        _evaluator: &'a mut Option<UnaryEvaluatorBox>,
+        _ty: &'a mut LogicalType,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)
+    }
+
+    fn visit_binary(
+        &mut self,
+        _op: &'a mut BinaryOperator,
+        left_expr: &'a mut ScalarExpression,
+        right_expr: &'a mut ScalarExpression,
+        _evaluator: &'a mut Option<BinaryEvaluatorBox>,
+        _ty: &'a mut LogicalType,
+    ) -> Result<(), DatabaseError> {
+        self.visit(left_expr)?;
+        self.visit(right_expr)
+    }
+
+    fn visit_agg(
+        &mut self,
+        _distinct: bool,
+        _kind: &'a mut AggKind,
+        args: &'a mut [ScalarExpression],
+        _ty: &'a mut LogicalType,
+    ) -> Result<(), DatabaseError> {
+        for arg in args {
+            self.visit(arg)?;
+        }
+        Ok(())
+    }
+
+    fn visit_in(
+        &mut self,
+        _negated: bool,
+        expr: &'a mut ScalarExpression,
+        args: &'a mut [ScalarExpression],
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)?;
+        for arg in args {
+            self.visit(arg)?;
+        }
+        Ok(())
+    }
+
+    fn visit_between(
+        &mut self,
+        _negated: bool,
+        expr: &'a mut ScalarExpression,
+        left_expr: &'a mut ScalarExpression,
+        right_expr: &'a mut ScalarExpression,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)?;
+        self.visit(left_expr)?;
+        self.visit(right_expr)
+    }
+
+    fn visit_substring(
+        &mut self,
+        expr: &'a mut ScalarExpression,
+        for_expr: &'a mut Option<Box<ScalarExpression>>,
+        from_expr: &'a mut Option<Box<ScalarExpression>>,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)?;
+        if let Some(for_expr) = for_expr {
+            self.visit(for_expr)?;
+        }
+        if let Some(from_expr) = from_expr {
+            self.visit(from_expr)?;
+        }
+        Ok(())
+    }
+
+    fn visit_position(
+        &mut self,
+        expr: &'a mut ScalarExpression,
+        in_expr: &'a mut ScalarExpression,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)?;
+        self.visit(in_expr)
+    }
+
+    fn visit_trim(
+        &mut self,
+        expr: &'a mut ScalarExpression,
+        trim_what_expr: &'a mut Option<Box<ScalarExpression>>,
+        _trim_where: &'a mut Option<TrimWhereField>,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)?;
+        if let Some(trim_what_expr) = trim_what_expr {
+            self.visit(trim_what_expr)?;
+        }
+        Ok(())
+    }
+
+    fn visit_empty(&mut self) -> Result<(), DatabaseError> {
+        Ok(())
+    }
+
+    fn visit_reference(
+        &mut self,
+        expr: &'a mut ScalarExpression,
+        _pos: usize,
+    ) -> Result<(), DatabaseError> {
+        self.visit(expr)
+    }
+
+    fn visit_tuple(&mut self, exprs: &'a mut [ScalarExpression]) -> Result<(), DatabaseError> {
+        for expr in exprs {
+            self.visit(expr)?;
+        }
+        Ok(())
+    }
+
+    fn visit_scala_function(
+        &mut self,
+        scalar_function: &'a mut ScalarFunction,
+    ) -> Result<(), DatabaseError> {
+        for arg in &mut scalar_function.args {
+            self.visit(arg)?;
+        }
+        Ok(())
+    }
+
+    fn visit_table_function(
+        &mut self,
+        table_function: &'a mut TableFunction,
+    ) -> Result<(), DatabaseError> {
+        for arg in &mut table_function.args {
+            self.visit(arg)?;
+        }
+        Ok(())
+    }
+
+    fn visit_if(
+        &mut self,
+        condition: &'a mut ScalarExpression,
+        left_expr: &'a mut ScalarExpression,
+        right_expr: &'a mut ScalarExpression,
+        _ty: &'a mut LogicalType,
+    ) -> Result<(), DatabaseError> {
+        self.visit(condition)?;
+        self.visit(left_expr)?;
+        self.visit(right_expr)
+    }
+
+    fn visit_if_null(
+        &mut self,
+        left_expr: &'a mut ScalarExpression,
+        right_expr: &'a mut ScalarExpression,
+        _ty: &'a mut LogicalType,
+    ) -> Result<(), DatabaseError> {
+        self.visit(left_expr)?;
+        self.visit(right_expr)
+    }
+
+    fn visit_null_if(
+        &mut self,
+        left_expr: &'a mut ScalarExpression,
+        right_expr: &'a mut ScalarExpression,
+        _ty: &'a mut LogicalType,
+    ) -> Result<(), DatabaseError> {
+        self.visit(left_expr)?;
+        self.visit(right_expr)
+    }
+
+    fn visit_coalesce(
+        &mut self,
+        exprs: &'a mut [ScalarExpression],
+        _ty: &'a mut LogicalType,
+    ) -> Result<(), DatabaseError> {
+        for expr in exprs {
+            self.visit(expr)?;
+        }
+        Ok(())
+    }
+
+    fn visit_case_when(
+        &mut self,
+        operand_expr: &'a mut Option<Box<ScalarExpression>>,
+        expr_pairs: &'a mut [(ScalarExpression, ScalarExpression)],
+        else_expr: &'a mut Option<Box<ScalarExpression>>,
+        _ty: &'a mut LogicalType,
+    ) -> Result<(), DatabaseError> {
+        if let Some(operand_expr) = operand_expr {
+            self.visit(operand_expr)?;
+        }
+        for (left_expr, right_expr) in expr_pairs {
+            self.visit(left_expr)?;
+            self.visit(right_expr)?;
+        }
+        if let Some(else_expr) = else_expr {
+            self.visit(else_expr)?;
+        }
+        Ok(())
+    }
+}
+
+#[recursive::recursive]
+pub fn walk_mut_expr<'a, V: VisitorMut<'a>>(
+    visitor: &mut V,
+    expr: &'a mut ScalarExpression,
+) -> Result<(), DatabaseError> {
+    match expr {
+        ScalarExpression::Constant(value) => visitor.visit_constant(value),
+        ScalarExpression::ColumnRef(column_ref) => visitor.visit_column_ref(column_ref),
+        ScalarExpression::Alias { expr, alias } => visitor.visit_alias(expr, alias),
+        ScalarExpression::TypeCast { expr, ty } => visitor.visit_type_cast(expr, ty),
+        ScalarExpression::IsNull { negated, expr } => visitor.visit_is_null(*negated, expr),
+        ScalarExpression::Unary {
+            op,
+            expr,
+            evaluator,
+            ty,
+        } => visitor.visit_unary(op, expr, evaluator, ty),
+        ScalarExpression::Binary {
+            op,
+            left_expr,
+            right_expr,
+            evaluator,
+            ty,
+        } => visitor.visit_binary(op, left_expr, right_expr, evaluator, ty),
+        ScalarExpression::AggCall {
+            distinct,
+            kind,
+            args,
+            ty,
+        } => visitor.visit_agg(*distinct, kind, args, ty),
+        ScalarExpression::In {
+            negated,
+            expr,
+            args,
+        } => visitor.visit_in(*negated, expr, args),
+        ScalarExpression::Between {
+            negated,
+            expr,
+            left_expr,
+            right_expr,
+        } => visitor.visit_between(*negated, expr, left_expr, right_expr),
+        ScalarExpression::SubString {
+            expr,
+            for_expr,
+            from_expr,
+        } => visitor.visit_substring(expr, for_expr, from_expr),
+        ScalarExpression::Position { expr, in_expr } => visitor.visit_position(expr, in_expr),
+        ScalarExpression::Trim {
+            expr,
+            trim_what_expr,
+            trim_where,
+        } => visitor.visit_trim(expr, trim_what_expr, trim_where),
+        ScalarExpression::Empty => visitor.visit_empty(),
+        ScalarExpression::Reference { expr, pos } => visitor.visit_reference(expr, *pos),
+        ScalarExpression::Tuple(exprs) => visitor.visit_tuple(exprs),
+        ScalarExpression::ScalaFunction(scalar_function) => {
+            visitor.visit_scala_function(scalar_function)
+        }
+        ScalarExpression::TableFunction(table_function) => {
+            visitor.visit_table_function(table_function)
+        }
+        ScalarExpression::If {
+            condition,
+            left_expr,
+            right_expr,
+            ty,
+        } => visitor.visit_if(condition, left_expr, right_expr, ty),
+        ScalarExpression::IfNull {
+            left_expr,
+            right_expr,
+            ty,
+        } => visitor.visit_if_null(left_expr, right_expr, ty),
+        ScalarExpression::NullIf {
+            left_expr,
+            right_expr,
+            ty,
+        } => visitor.visit_null_if(left_expr, right_expr, ty),
+        ScalarExpression::Coalesce { exprs, ty } => visitor.visit_coalesce(exprs, ty),
+        ScalarExpression::CaseWhen {
+            operand_expr,
+            expr_pairs,
+            else_expr,
+            ty,
+        } => visitor.visit_case_when(operand_expr, expr_pairs, else_expr, ty),
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Using Visitor simplifies expression convenience
- ConstantCalculator
- Simplify
- TryReference
- BindEvaluator
- HasCountStar

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
