### PR TITLE
test: add e2e test `crdb/where.slt`

### DIFF
--- a/src/binder/insert.rs
+++ b/src/binder/insert.rs
@@ -74,8 +74,12 @@ impl<T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'_, '_, T, A>
 
                 ConstantCalculator.visit(&mut expression)?;
                 match expression {
-                    ScalarExpression::Constant(value) => {
+                    ScalarExpression::Constant(mut value) => {
                         let ty = schema_ref[i].datatype();
+
+                        if &value.logical_type() != ty {
+                            value = value.cast(ty)?;
+                        }
                         // Check if the value length is too long
                         value.check_len(ty)?;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,8 +19,8 @@ pub enum DatabaseError {
     ),
     #[error("cache size overflow")]
     CacheSizeOverFlow,
-    #[error("cast fail")]
-    CastFail,
+    #[error("cast fail: {from} -> {to}")]
+    CastFail { from: LogicalType, to: LogicalType },
     #[error("channel close")]
     ChannelClose,
     #[error("columns empty")]
@@ -89,8 +89,10 @@ pub enum DatabaseError {
     ParametersNotFound(String),
     #[error("no transaction begin")]
     NoTransactionBegin,
-    #[error("cannot be Null")]
+    #[error("cannot be null")]
     NotNull,
+    #[error("over flow")]
+    OverFlow,
     #[error("parser bool: {0}")]
     ParseBool(
         #[source]

--- a/src/execution/dql/aggregate/avg.rs
+++ b/src/execution/dql/aggregate/avg.rs
@@ -56,6 +56,6 @@ impl Accumulator for AvgAccumulator {
             value = value.cast(&quantity_ty)?
         }
         let evaluator = EvaluatorFactory::binary_create(quantity_ty, BinaryOperator::Divide)?;
-        Ok(evaluator.0.binary_eval(&value, &quantity))
+        evaluator.0.binary_eval(&value, &quantity)
     }
 }

--- a/src/execution/dql/aggregate/min_max.rs
+++ b/src/execution/dql/aggregate/min_max.rs
@@ -26,7 +26,7 @@ impl Accumulator for MinMaxAccumulator {
         if !value.is_null() {
             if let Some(inner_value) = &self.inner {
                 let evaluator = EvaluatorFactory::binary_create(value.logical_type(), self.op)?;
-                if let DataValue::Boolean(result) = evaluator.0.binary_eval(inner_value, value) {
+                if let DataValue::Boolean(result) = evaluator.0.binary_eval(inner_value, value)? {
                     result
                 } else {
                     return Err(DatabaseError::InvalidType);

--- a/src/execution/dql/aggregate/sum.rs
+++ b/src/execution/dql/aggregate/sum.rs
@@ -29,7 +29,7 @@ impl Accumulator for SumAccumulator {
             if self.result.is_null() {
                 self.result = value.clone();
             } else {
-                self.result = self.evaluator.0.binary_eval(&self.result, value);
+                self.result = self.evaluator.0.binary_eval(&self.result, value)?;
             }
         }
 

--- a/src/expression/evaluator.rs
+++ b/src/expression/evaluator.rs
@@ -76,11 +76,11 @@ impl ScalarExpression {
                 let left = left_expr.eval(tuple)?;
                 let right = right_expr.eval(tuple)?;
 
-                Ok(evaluator
+                evaluator
                     .as_ref()
                     .ok_or(DatabaseError::EvaluatorNotFound)?
                     .0
-                    .binary_eval(&left, &right))
+                    .binary_eval(&left, &right)
             }
             ScalarExpression::IsNull { expr, negated } => {
                 let mut is_null = expr.eval(tuple)?.is_null();
@@ -340,7 +340,7 @@ impl ScalarExpression {
                         }
                         evaluator
                             .0
-                            .binary_eval(operand_value, &when_value)
+                            .binary_eval(operand_value, &when_value)?
                             .is_true()?
                     } else {
                         when_value.is_true()?

--- a/src/expression/range_detacher.rs
+++ b/src/expression/range_detacher.rs
@@ -450,6 +450,7 @@ impl<'a> RangeDetacher<'a> {
         }
     }
 
+    #[allow(unreachable_code)]
     fn extract_merge_ranges(
         op: BinaryOperator,
         mut binary: Option<Range>,
@@ -562,9 +563,12 @@ impl<'a> RangeDetacher<'a> {
                     );
                 }
                 (None, _) => break,
-                w => {
-                    println!("{:#?}", w);
-                    unreachable!()
+                _ => {
+                    #[cfg(debug_assertions)]
+                    {
+                        unreachable!();
+                    }
+                    return vec![];
                 }
             }
         }

--- a/src/expression/simplify.rs
+++ b/src/expression/simplify.rs
@@ -79,7 +79,7 @@ impl VisitorMut<'_> for ConstantCalculator {
                     if right_val.logical_type() != ty {
                         *right_val = right_val.clone().cast(&ty)?;
                     }
-                    let value = evaluator.0.binary_eval(left_val, right_val);
+                    let value = evaluator.0.binary_eval(left_val, right_val)?;
                     let _ = mem::replace(expr, ScalarExpression::Constant(value));
                 }
             }
@@ -467,15 +467,15 @@ impl ScalarExpression {
                 if &right.logical_type() != ty {
                     right = right.cast(ty).ok()?;
                 }
-                let binary_value = if let Some(evaluator) = evaluator {
+                if let Some(evaluator) = evaluator {
                     evaluator.0.binary_eval(&left, &right)
                 } else {
                     EvaluatorFactory::binary_create(ty.clone(), *op)
                         .ok()?
                         .0
                         .binary_eval(&left, &right)
-                };
-                Some(binary_value)
+                }
+                .ok()
             }
             _ => None,
         }

--- a/src/optimizer/core/histogram.rs
+++ b/src/optimizer/core/histogram.rs
@@ -215,7 +215,7 @@ fn is_under(
                 BinaryOperator::LtEq
             },
         )?;
-        let value = evaluator.0.binary_eval(value, target);
+        let value = evaluator.0.binary_eval(value, target)?;
         Ok::<bool, DatabaseError>(matches!(value, DataValue::Boolean(true)))
     };
 
@@ -240,7 +240,7 @@ fn is_above(
                 BinaryOperator::Gt
             },
         )?;
-        let value = evaluator.0.binary_eval(value, target);
+        let value = evaluator.0.binary_eval(value, target)?;
         Ok::<bool, DatabaseError>(matches!(value, DataValue::Boolean(true)))
     };
     Ok(match target {
@@ -331,7 +331,7 @@ impl Histogram {
                 },
                 LogicalType::Date
                 | LogicalType::DateTime
-                | LogicalType::Time(_, _)
+                | LogicalType::Time(_)
                 | LogicalType::TimeStamp(_, _) => match value {
                     DataValue::Date32(value) => DataValue::Int32(*value)
                         .cast(&LogicalType::Double)?

--- a/src/optimizer/rule/normalization/simplification.rs
+++ b/src/optimizer/rule/normalization/simplification.rs
@@ -163,7 +163,7 @@ mod test {
         let filter_op = best_plan.childrens.pop_only();
         if let Operator::Filter(filter_op) = filter_op.operator {
             let range = RangeDetacher::new("t1", table_state.column_id_by_name("c1"))
-                .detach(&filter_op.predicate)
+                .detach(&filter_op.predicate)?
                 .unwrap();
             assert_eq!(
                 range,
@@ -217,7 +217,7 @@ mod test {
             if let Operator::Filter(filter_op) = filter_op.operator {
                 Ok(
                     RangeDetacher::new("t1", table_state.column_id_by_name("c1"))
-                        .detach(&filter_op.predicate),
+                        .detach(&filter_op.predicate)?,
                 )
             } else {
                 Ok(None)
@@ -332,7 +332,7 @@ mod test {
 
         let filter_op = best_plan.childrens.pop_only();
         if let Operator::Filter(filter_op) = filter_op.operator {
-            Ok(RangeDetacher::new("t1", &column_id).detach(&filter_op.predicate))
+            Ok(RangeDetacher::new("t1", &column_id).detach(&filter_op.predicate)?)
         } else {
             Ok(None)
         }

--- a/src/types/evaluator/boolean.rs
+++ b/src/types/evaluator/boolean.rs
@@ -1,3 +1,4 @@
+use crate::errors::DatabaseError;
 use crate::types::evaluator::DataValue;
 use crate::types::evaluator::{BinaryEvaluator, UnaryEvaluator};
 use serde::{Deserialize, Serialize};
@@ -26,8 +27,8 @@ impl UnaryEvaluator for BooleanNotUnaryEvaluator {
 }
 #[typetag::serde]
 impl BinaryEvaluator for BooleanAndBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Boolean(v1), DataValue::Boolean(v2)) => DataValue::Boolean(*v1 && *v2),
             (DataValue::Boolean(false), DataValue::Null)
             | (DataValue::Null, DataValue::Boolean(false)) => DataValue::Boolean(false),
@@ -35,14 +36,14 @@ impl BinaryEvaluator for BooleanAndBinaryEvaluator {
             | (DataValue::Boolean(true), DataValue::Null)
             | (DataValue::Null, DataValue::Boolean(true)) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 
 #[typetag::serde]
 impl BinaryEvaluator for BooleanOrBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Boolean(v1), DataValue::Boolean(v2)) => DataValue::Boolean(*v1 || *v2),
             (DataValue::Boolean(true), DataValue::Null)
             | (DataValue::Null, DataValue::Boolean(true)) => DataValue::Boolean(true),
@@ -50,32 +51,32 @@ impl BinaryEvaluator for BooleanOrBinaryEvaluator {
             | (DataValue::Boolean(false), DataValue::Null)
             | (DataValue::Null, DataValue::Boolean(false)) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 
 #[typetag::serde]
 impl BinaryEvaluator for BooleanEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Boolean(v1), DataValue::Boolean(v2)) => DataValue::Boolean(*v1 == *v2),
             (DataValue::Null, DataValue::Boolean(_))
             | (DataValue::Boolean(_), DataValue::Null)
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 
 #[typetag::serde]
 impl BinaryEvaluator for BooleanNotEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Boolean(v1), DataValue::Boolean(v2)) => DataValue::Boolean(*v1 != *v2),
             (DataValue::Null, DataValue::Boolean(_))
             | (DataValue::Boolean(_), DataValue::Null)
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }

--- a/src/types/evaluator/date.rs
+++ b/src/types/evaluator/date.rs
@@ -1,6 +1,7 @@
 use crate::numeric_binary_evaluator_definition;
 use crate::types::evaluator::BinaryEvaluator;
 use crate::types::evaluator::DataValue;
+use crate::types::DatabaseError;
 use paste::paste;
 use serde::{Deserialize, Serialize};
 use std::hint;

--- a/src/types/evaluator/datetime.rs
+++ b/src/types/evaluator/datetime.rs
@@ -1,6 +1,7 @@
 use crate::numeric_binary_evaluator_definition;
 use crate::types::evaluator::BinaryEvaluator;
 use crate::types::evaluator::DataValue;
+use crate::types::DatabaseError;
 use paste::paste;
 use serde::{Deserialize, Serialize};
 use std::hint;

--- a/src/types/evaluator/decimal.rs
+++ b/src/types/evaluator/decimal.rs
@@ -1,3 +1,4 @@
+use crate::errors::DatabaseError;
 use crate::types::evaluator::BinaryEvaluator;
 use crate::types::evaluator::DataValue;
 use serde::{Deserialize, Serialize};
@@ -28,133 +29,133 @@ pub struct DecimalModBinaryEvaluator;
 
 #[typetag::serde]
 impl BinaryEvaluator for DecimalPlusBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Decimal(v1), DataValue::Decimal(v2)) => DataValue::Decimal(v1 + v2),
             (DataValue::Decimal(_), DataValue::Null)
             | (DataValue::Null, DataValue::Decimal(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for DecimalMinusBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Decimal(v1), DataValue::Decimal(v2)) => DataValue::Decimal(v1 - v2),
             (DataValue::Decimal(_), DataValue::Null)
             | (DataValue::Null, DataValue::Decimal(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for DecimalMultiplyBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Decimal(v1), DataValue::Decimal(v2)) => DataValue::Decimal(v1 * v2),
             (DataValue::Decimal(_), DataValue::Null)
             | (DataValue::Null, DataValue::Decimal(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for DecimalDivideBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Decimal(v1), DataValue::Decimal(v2)) => DataValue::Decimal(v1 / v2),
             (DataValue::Decimal(_), DataValue::Null)
             | (DataValue::Null, DataValue::Decimal(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for DecimalGtBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Decimal(v1), DataValue::Decimal(v2)) => DataValue::Boolean(v1 > v2),
             (DataValue::Decimal(_), DataValue::Null)
             | (DataValue::Null, DataValue::Decimal(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for DecimalGtEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Decimal(v1), DataValue::Decimal(v2)) => DataValue::Boolean(v1 >= v2),
             (DataValue::Decimal(_), DataValue::Null)
             | (DataValue::Null, DataValue::Decimal(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for DecimalLtBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Decimal(v1), DataValue::Decimal(v2)) => DataValue::Boolean(v1 < v2),
             (DataValue::Decimal(_), DataValue::Null)
             | (DataValue::Null, DataValue::Decimal(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for DecimalLtEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Decimal(v1), DataValue::Decimal(v2)) => DataValue::Boolean(v1 <= v2),
             (DataValue::Decimal(_), DataValue::Null)
             | (DataValue::Null, DataValue::Decimal(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for DecimalEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Decimal(v1), DataValue::Decimal(v2)) => DataValue::Boolean(v1 == v2),
             (DataValue::Decimal(_), DataValue::Null)
             | (DataValue::Null, DataValue::Decimal(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for DecimalNotEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Decimal(v1), DataValue::Decimal(v2)) => DataValue::Boolean(v1 != v2),
             (DataValue::Decimal(_), DataValue::Null)
             | (DataValue::Null, DataValue::Decimal(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for DecimalModBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Decimal(v1), DataValue::Decimal(v2)) => DataValue::Decimal(v1 % v2),
             (DataValue::Decimal(_), DataValue::Null)
             | (DataValue::Null, DataValue::Decimal(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }

--- a/src/types/evaluator/float32.rs
+++ b/src/types/evaluator/float32.rs
@@ -1,3 +1,4 @@
+use crate::errors::DatabaseError;
 use crate::types::evaluator::DataValue;
 use crate::types::evaluator::{BinaryEvaluator, UnaryEvaluator};
 use serde::{Deserialize, Serialize};
@@ -50,44 +51,44 @@ pub struct Float32ModBinaryEvaluator;
 
 #[typetag::serde]
 impl BinaryEvaluator for Float32PlusBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float32(v1), DataValue::Float32(v2)) => DataValue::Float32(*v1 + *v2),
             (DataValue::Float32(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float32(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float32MinusBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float32(v1), DataValue::Float32(v2)) => DataValue::Float32(*v1 - *v2),
             (DataValue::Float32(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float32(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float32MultiplyBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float32(v1), DataValue::Float32(v2)) => DataValue::Float32(*v1 * *v2),
             (DataValue::Float32(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float32(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float32DivideBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float32(v1), DataValue::Float32(v2)) => {
                 DataValue::Float64(ordered_float::OrderedFloat(**v1 as f64 / **v2 as f64))
             }
@@ -95,90 +96,90 @@ impl BinaryEvaluator for Float32DivideBinaryEvaluator {
             | (DataValue::Null, DataValue::Float32(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float32GtBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float32(v1), DataValue::Float32(v2)) => DataValue::Boolean(v1 > v2),
             (DataValue::Float32(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float32(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float32GtEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float32(v1), DataValue::Float32(v2)) => DataValue::Boolean(v1 >= v2),
             (DataValue::Float32(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float32(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float32LtBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float32(v1), DataValue::Float32(v2)) => DataValue::Boolean(v1 < v2),
             (DataValue::Float32(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float32(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float32LtEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float32(v1), DataValue::Float32(v2)) => DataValue::Boolean(v1 <= v2),
             (DataValue::Float32(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float32(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float32EqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float32(v1), DataValue::Float32(v2)) => DataValue::Boolean(v1 == v2),
             (DataValue::Float32(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float32(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float32NotEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float32(v1), DataValue::Float32(v2)) => DataValue::Boolean(v1 != v2),
             (DataValue::Float32(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float32(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float32ModBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float32(v1), DataValue::Float32(v2)) => DataValue::Float32(*v1 % *v2),
             (DataValue::Float32(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float32(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }

--- a/src/types/evaluator/float64.rs
+++ b/src/types/evaluator/float64.rs
@@ -1,3 +1,4 @@
+use crate::errors::DatabaseError;
 use crate::types::evaluator::DataValue;
 use crate::types::evaluator::{BinaryEvaluator, UnaryEvaluator};
 use serde::{Deserialize, Serialize};
@@ -50,44 +51,44 @@ pub struct Float64ModBinaryEvaluator;
 
 #[typetag::serde]
 impl BinaryEvaluator for Float64PlusBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float64(v1), DataValue::Float64(v2)) => DataValue::Float64(*v1 + *v2),
             (DataValue::Float64(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float64(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float64MinusBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float64(v1), DataValue::Float64(v2)) => DataValue::Float64(*v1 - *v2),
             (DataValue::Float64(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float64(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float64MultiplyBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float64(v1), DataValue::Float64(v2)) => DataValue::Float64(*v1 * *v2),
             (DataValue::Float64(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float64(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float64DivideBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float64(v1), DataValue::Float64(v2)) => {
                 DataValue::Float64(ordered_float::OrderedFloat(**v1 / **v2))
             }
@@ -95,90 +96,90 @@ impl BinaryEvaluator for Float64DivideBinaryEvaluator {
             | (DataValue::Null, DataValue::Float64(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float64GtBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float64(v1), DataValue::Float64(v2)) => DataValue::Boolean(v1 > v2),
             (DataValue::Float64(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float64(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float64GtEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float64(v1), DataValue::Float64(v2)) => DataValue::Boolean(v1 >= v2),
             (DataValue::Float64(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float64(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float64LtBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float64(v1), DataValue::Float64(v2)) => DataValue::Boolean(v1 < v2),
             (DataValue::Float64(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float64(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float64LtEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float64(v1), DataValue::Float64(v2)) => DataValue::Boolean(v1 <= v2),
             (DataValue::Float64(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float64(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float64EqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float64(v1), DataValue::Float64(v2)) => DataValue::Boolean(v1 == v2),
             (DataValue::Float64(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float64(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float64NotEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float64(v1), DataValue::Float64(v2)) => DataValue::Boolean(v1 != v2),
             (DataValue::Float64(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float64(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Float64ModBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Float64(v1), DataValue::Float64(v2)) => DataValue::Float64(*v1 % *v2),
             (DataValue::Float64(_), DataValue::Null)
             | (DataValue::Null, DataValue::Float64(_))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }

--- a/src/types/evaluator/int16.rs
+++ b/src/types/evaluator/int16.rs
@@ -1,5 +1,6 @@
 use crate::types::evaluator::DataValue;
 use crate::types::evaluator::{BinaryEvaluator, UnaryEvaluator};
+use crate::types::DatabaseError;
 use crate::{numeric_binary_evaluator_definition, numeric_unary_evaluator_definition};
 use paste::paste;
 use serde::{Deserialize, Serialize};

--- a/src/types/evaluator/int32.rs
+++ b/src/types/evaluator/int32.rs
@@ -1,5 +1,6 @@
 use crate::types::evaluator::DataValue;
 use crate::types::evaluator::{BinaryEvaluator, UnaryEvaluator};
+use crate::types::DatabaseError;
 use crate::{numeric_binary_evaluator_definition, numeric_unary_evaluator_definition};
 use paste::paste;
 use serde::{Deserialize, Serialize};

--- a/src/types/evaluator/int64.rs
+++ b/src/types/evaluator/int64.rs
@@ -1,5 +1,6 @@
 use crate::types::evaluator::DataValue;
 use crate::types::evaluator::{BinaryEvaluator, UnaryEvaluator};
+use crate::types::DatabaseError;
 use crate::{numeric_binary_evaluator_definition, numeric_unary_evaluator_definition};
 use paste::paste;
 use serde::{Deserialize, Serialize};

--- a/src/types/evaluator/int8.rs
+++ b/src/types/evaluator/int8.rs
@@ -1,5 +1,6 @@
 use crate::types::evaluator::DataValue;
 use crate::types::evaluator::{BinaryEvaluator, UnaryEvaluator};
+use crate::types::DatabaseError;
 use crate::{numeric_binary_evaluator_definition, numeric_unary_evaluator_definition};
 use paste::paste;
 use serde::{Deserialize, Serialize};

--- a/src/types/evaluator/mod.rs
+++ b/src/types/evaluator/mod.rs
@@ -52,11 +52,12 @@ use paste::paste;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
+use std::ops::Deref;
 use std::sync::Arc;
 
 #[typetag::serde(tag = "binary")]
 pub trait BinaryEvaluator: Send + Sync + Debug {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue;
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError>;
 }
 
 #[typetag::serde(tag = "unary")]
@@ -67,8 +68,20 @@ pub trait UnaryEvaluator: Send + Sync + Debug {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BinaryEvaluatorBox(pub Arc<dyn BinaryEvaluator>);
 
+impl Deref for BinaryEvaluatorBox {
+    type Target = Arc<dyn BinaryEvaluator>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl BinaryEvaluatorBox {
-    pub fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
+    pub fn binary_eval(
+        &self,
+        left: &DataValue,
+        right: &DataValue,
+    ) -> Result<DataValue, DatabaseError> {
         self.0.binary_eval(left, right)
     }
 }
@@ -193,7 +206,7 @@ impl EvaluatorFactory {
             LogicalType::Double => numeric_binary_evaluator!(Float64, op, LogicalType::Double),
             LogicalType::Date => numeric_binary_evaluator!(Date, op, LogicalType::Date),
             LogicalType::DateTime => numeric_binary_evaluator!(DateTime, op, LogicalType::DateTime),
-            LogicalType::Time(_, _) => match op {
+            LogicalType::Time(_) => match op {
                 BinaryOperator::Plus => Ok(BinaryEvaluatorBox(Arc::new(TimePlusBinaryEvaluator))),
                 BinaryOperator::Minus => Ok(BinaryEvaluatorBox(Arc::new(TimeMinusBinaryEvaluator))),
                 BinaryOperator::Gt => Ok(BinaryEvaluatorBox(Arc::new(TimeGtBinaryEvaluator))),
@@ -324,112 +337,112 @@ macro_rules! numeric_binary_evaluator_definition {
 
             #[typetag::serde]
             impl BinaryEvaluator for [<$value_type PlusBinaryEvaluator>] {
-                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-                    match (left, right) {
-                        ($compute_type(v1), $compute_type(v2)) => $compute_type(*v1 + *v2),
+                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+                    Ok(match (left, right) {
+                        ($compute_type(v1), $compute_type(v2)) => $compute_type(v1.checked_add(*v2).ok_or(DatabaseError::OverFlow)?),
                         ($compute_type(_), DataValue::Null) | (DataValue::Null, $compute_type(_)) | (DataValue::Null, DataValue::Null) => DataValue::Null,
                         _ => unsafe { hint::unreachable_unchecked() },
-                    }
+                    })
                 }
             }
             #[typetag::serde]
             impl BinaryEvaluator for [<$value_type MinusBinaryEvaluator>] {
-                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-                    match (left, right) {
-                        ($compute_type(v1), $compute_type(v2)) => $compute_type(*v1 - *v2),
+                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+                    Ok(match (left, right) {
+                        ($compute_type(v1), $compute_type(v2)) => $compute_type(v1.checked_sub(*v2).ok_or(DatabaseError::OverFlow)?),
                         ($compute_type(_), DataValue::Null) | (DataValue::Null, $compute_type(_)) | (DataValue::Null, DataValue::Null) => DataValue::Null,
                         _ => unsafe { hint::unreachable_unchecked() },
-                    }
+                    })
                 }
             }
             #[typetag::serde]
             impl BinaryEvaluator for [<$value_type MultiplyBinaryEvaluator>] {
-                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-                    match (left, right) {
-                        ($compute_type(v1), $compute_type(v2)) => $compute_type(*v1 * *v2),
+                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+                    Ok(match (left, right) {
+                        ($compute_type(v1), $compute_type(v2)) => $compute_type(v1.checked_mul(*v2).ok_or(DatabaseError::OverFlow)?),
                         ($compute_type(_), DataValue::Null) | (DataValue::Null, $compute_type(_)) | (DataValue::Null, DataValue::Null) => DataValue::Null,
                         _ => unsafe { hint::unreachable_unchecked() },
-                    }
+                    })
                 }
             }
             #[typetag::serde]
             impl BinaryEvaluator for [<$value_type DivideBinaryEvaluator>] {
-                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-                    match (left, right) {
+                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+                    Ok(match (left, right) {
                         ($compute_type(v1), $compute_type(v2)) => DataValue::Float64(ordered_float::OrderedFloat(*v1 as f64 / *v2 as f64)),
                         ($compute_type(_), DataValue::Null) | (DataValue::Null, $compute_type(_)) | (DataValue::Null, DataValue::Null) => DataValue::Null,
                         _ => unsafe { hint::unreachable_unchecked() },
-                    }
+                    })
                 }
             }
             #[typetag::serde]
             impl BinaryEvaluator for [<$value_type GtBinaryEvaluator>] {
-                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-                    match (left, right) {
+                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+                    Ok(match (left, right) {
                         ($compute_type(v1), $compute_type(v2)) => DataValue::Boolean(v1 > v2),
                         ($compute_type(_), DataValue::Null) | (DataValue::Null, $compute_type(_)) | (DataValue::Null, DataValue::Null) => DataValue::Null,
                         _ => unsafe { hint::unreachable_unchecked() },
-                    }
+                    })
                 }
             }
             #[typetag::serde]
             impl BinaryEvaluator for [<$value_type GtEqBinaryEvaluator>] {
-                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-                    match (left, right) {
+                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+                    Ok(match (left, right) {
                         ($compute_type(v1), $compute_type(v2)) => DataValue::Boolean(v1 >= v2),
                         ($compute_type(_), DataValue::Null) | (DataValue::Null, $compute_type(_)) | (DataValue::Null, DataValue::Null) => DataValue::Null,
                         _ => unsafe { hint::unreachable_unchecked() },
-                    }
+                    })
                 }
             }
             #[typetag::serde]
             impl BinaryEvaluator for [<$value_type LtBinaryEvaluator>] {
-                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-                    match (left, right) {
+                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+                    Ok(match (left, right) {
                         ($compute_type(v1), $compute_type(v2)) => DataValue::Boolean(v1 < v2),
                         ($compute_type(_), DataValue::Null) | (DataValue::Null, $compute_type(_)) | (DataValue::Null, DataValue::Null) => DataValue::Null,
                         _ => unsafe { hint::unreachable_unchecked() },
-                    }
+                    })
                 }
             }
             #[typetag::serde]
             impl BinaryEvaluator for [<$value_type LtEqBinaryEvaluator>] {
-                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-                    match (left, right) {
+                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+                    Ok(match (left, right) {
                         ($compute_type(v1), $compute_type(v2)) => DataValue::Boolean(v1 <= v2),
                         ($compute_type(_), DataValue::Null) | (DataValue::Null, $compute_type(_)) | (DataValue::Null, DataValue::Null) => DataValue::Null,
                         _ => unsafe { hint::unreachable_unchecked() },
-                    }
+                    })
                 }
             }
             #[typetag::serde]
             impl BinaryEvaluator for [<$value_type EqBinaryEvaluator>] {
-                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-                    match (left, right) {
+                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+                    Ok(match (left, right) {
                         ($compute_type(v1), $compute_type(v2)) => DataValue::Boolean(v1 == v2),
                         ($compute_type(_), DataValue::Null) | (DataValue::Null, $compute_type(_)) | (DataValue::Null, DataValue::Null) => DataValue::Null,
                         _ => unsafe { hint::unreachable_unchecked() },
-                    }
+                    })
                 }
             }
             #[typetag::serde]
             impl BinaryEvaluator for [<$value_type NotEqBinaryEvaluator>] {
-                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-                    match (left, right) {
+                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+                    Ok(match (left, right) {
                         ($compute_type(v1), $compute_type(v2)) => DataValue::Boolean(v1 != v2),
                         ($compute_type(_), DataValue::Null) | (DataValue::Null, $compute_type(_)) | (DataValue::Null, DataValue::Null) => DataValue::Null,
                         _ => unsafe { hint::unreachable_unchecked() },
-                    }
+                    })
                 }
             }
             #[typetag::serde]
             impl BinaryEvaluator for [<$value_type ModBinaryEvaluator>] {
-                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-                    match (left, right) {
+                fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+                    Ok(match (left, right) {
                         ($compute_type(v1), $compute_type(v2)) => $compute_type(*v1 % *v2),
                         ($compute_type(_), DataValue::Null) | (DataValue::Null, $compute_type(_)) | (DataValue::Null, DataValue::Null) => DataValue::Null,
                         _ => unsafe { hint::unreachable_unchecked() },
-                    }
+                    })
                 }
             }
         }
@@ -457,16 +470,16 @@ mod test {
             EvaluatorFactory::binary_create(LogicalType::Integer, BinaryOperator::Plus)?;
         let plus_i32_1 = plus_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Null);
+            .binary_eval(&DataValue::Null, &DataValue::Null)?;
         let plus_i32_2 = plus_evaluator
             .0
-            .binary_eval(&DataValue::Int32(1), &DataValue::Null);
+            .binary_eval(&DataValue::Int32(1), &DataValue::Null)?;
         let plus_i32_3 = plus_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Int32(1));
+            .binary_eval(&DataValue::Null, &DataValue::Int32(1))?;
         let plus_i32_4 = plus_evaluator
             .0
-            .binary_eval(&DataValue::Int32(1), &DataValue::Int32(1));
+            .binary_eval(&DataValue::Int32(1), &DataValue::Int32(1))?;
 
         assert_eq!(plus_i32_1, plus_i32_2);
         assert_eq!(plus_i32_2, plus_i32_3);
@@ -476,16 +489,16 @@ mod test {
             EvaluatorFactory::binary_create(LogicalType::Bigint, BinaryOperator::Plus)?;
         let plus_i64_1 = plus_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Null);
+            .binary_eval(&DataValue::Null, &DataValue::Null)?;
         let plus_i64_2 = plus_evaluator
             .0
-            .binary_eval(&DataValue::Int64(1), &DataValue::Null);
+            .binary_eval(&DataValue::Int64(1), &DataValue::Null)?;
         let plus_i64_3 = plus_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Int64(1));
+            .binary_eval(&DataValue::Null, &DataValue::Int64(1))?;
         let plus_i64_4 = plus_evaluator
             .0
-            .binary_eval(&DataValue::Int64(1), &DataValue::Int64(1));
+            .binary_eval(&DataValue::Int64(1), &DataValue::Int64(1))?;
 
         assert_eq!(plus_i64_1, plus_i64_2);
         assert_eq!(plus_i64_2, plus_i64_3);
@@ -495,17 +508,17 @@ mod test {
             EvaluatorFactory::binary_create(LogicalType::Double, BinaryOperator::Plus)?;
         let plus_f64_1 = plus_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Null);
+            .binary_eval(&DataValue::Null, &DataValue::Null)?;
         let plus_f64_2 = plus_evaluator
             .0
-            .binary_eval(&DataValue::Float64(OrderedFloat(1.0)), &DataValue::Null);
+            .binary_eval(&DataValue::Float64(OrderedFloat(1.0)), &DataValue::Null)?;
         let plus_f64_3 = plus_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Float64(OrderedFloat(1.0)));
+            .binary_eval(&DataValue::Null, &DataValue::Float64(OrderedFloat(1.0)))?;
         let plus_f64_4 = plus_evaluator.0.binary_eval(
             &DataValue::Float64(OrderedFloat(1.0)),
             &DataValue::Float64(OrderedFloat(1.0)),
-        );
+        )?;
 
         assert_eq!(plus_f64_1, plus_f64_2);
         assert_eq!(plus_f64_2, plus_f64_3);
@@ -520,16 +533,16 @@ mod test {
             EvaluatorFactory::binary_create(LogicalType::Integer, BinaryOperator::Minus)?;
         let minus_i32_1 = minus_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Null);
+            .binary_eval(&DataValue::Null, &DataValue::Null)?;
         let minus_i32_2 = minus_evaluator
             .0
-            .binary_eval(&DataValue::Int32(1), &DataValue::Null);
+            .binary_eval(&DataValue::Int32(1), &DataValue::Null)?;
         let minus_i32_3 = minus_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Int32(1));
+            .binary_eval(&DataValue::Null, &DataValue::Int32(1))?;
         let minus_i32_4 = minus_evaluator
             .0
-            .binary_eval(&DataValue::Int32(1), &DataValue::Int32(1));
+            .binary_eval(&DataValue::Int32(1), &DataValue::Int32(1))?;
 
         assert_eq!(minus_i32_1, minus_i32_2);
         assert_eq!(minus_i32_2, minus_i32_3);
@@ -539,16 +552,16 @@ mod test {
             EvaluatorFactory::binary_create(LogicalType::Bigint, BinaryOperator::Minus)?;
         let minus_i64_1 = minus_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Null);
+            .binary_eval(&DataValue::Null, &DataValue::Null)?;
         let minus_i64_2 = minus_evaluator
             .0
-            .binary_eval(&DataValue::Int64(1), &DataValue::Null);
+            .binary_eval(&DataValue::Int64(1), &DataValue::Null)?;
         let minus_i64_3 = minus_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Int64(1));
+            .binary_eval(&DataValue::Null, &DataValue::Int64(1))?;
         let minus_i64_4 = minus_evaluator
             .0
-            .binary_eval(&DataValue::Int64(1), &DataValue::Int64(1));
+            .binary_eval(&DataValue::Int64(1), &DataValue::Int64(1))?;
 
         assert_eq!(minus_i64_1, minus_i64_2);
         assert_eq!(minus_i64_2, minus_i64_3);
@@ -558,17 +571,17 @@ mod test {
             EvaluatorFactory::binary_create(LogicalType::Double, BinaryOperator::Minus)?;
         let minus_f64_1 = minus_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Null);
+            .binary_eval(&DataValue::Null, &DataValue::Null)?;
         let minus_f64_2 = minus_evaluator
             .0
-            .binary_eval(&DataValue::Float64(OrderedFloat(1.0)), &DataValue::Null);
+            .binary_eval(&DataValue::Float64(OrderedFloat(1.0)), &DataValue::Null)?;
         let minus_f64_3 = minus_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Float64(OrderedFloat(1.0)));
+            .binary_eval(&DataValue::Null, &DataValue::Float64(OrderedFloat(1.0)))?;
         let minus_f64_4 = minus_evaluator.0.binary_eval(
             &DataValue::Float64(OrderedFloat(1.0)),
             &DataValue::Float64(OrderedFloat(1.0)),
-        );
+        )?;
 
         assert_eq!(minus_f64_1, minus_f64_2);
         assert_eq!(minus_f64_2, minus_f64_3);
@@ -583,16 +596,16 @@ mod test {
             EvaluatorFactory::binary_create(LogicalType::Integer, BinaryOperator::Multiply)?;
         let multiply_i32_1 = multiply_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Null);
+            .binary_eval(&DataValue::Null, &DataValue::Null)?;
         let multiply_i32_2 = multiply_evaluator
             .0
-            .binary_eval(&DataValue::Int32(1), &DataValue::Null);
+            .binary_eval(&DataValue::Int32(1), &DataValue::Null)?;
         let multiply_i32_3 = multiply_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Int32(1));
+            .binary_eval(&DataValue::Null, &DataValue::Int32(1))?;
         let multiply_i32_4 = multiply_evaluator
             .0
-            .binary_eval(&DataValue::Int32(1), &DataValue::Int32(1));
+            .binary_eval(&DataValue::Int32(1), &DataValue::Int32(1))?;
 
         assert_eq!(multiply_i32_1, multiply_i32_2);
         assert_eq!(multiply_i32_2, multiply_i32_3);
@@ -602,16 +615,16 @@ mod test {
             EvaluatorFactory::binary_create(LogicalType::Bigint, BinaryOperator::Multiply)?;
         let multiply_i64_1 = multiply_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Null);
+            .binary_eval(&DataValue::Null, &DataValue::Null)?;
         let multiply_i64_2 = multiply_evaluator
             .0
-            .binary_eval(&DataValue::Int64(1), &DataValue::Null);
+            .binary_eval(&DataValue::Int64(1), &DataValue::Null)?;
         let multiply_i64_3 = multiply_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Int64(1));
+            .binary_eval(&DataValue::Null, &DataValue::Int64(1))?;
         let multiply_i64_4 = multiply_evaluator
             .0
-            .binary_eval(&DataValue::Int64(1), &DataValue::Int64(1));
+            .binary_eval(&DataValue::Int64(1), &DataValue::Int64(1))?;
 
         assert_eq!(multiply_i64_1, multiply_i64_2);
         assert_eq!(multiply_i64_2, multiply_i64_3);
@@ -621,17 +634,17 @@ mod test {
             EvaluatorFactory::binary_create(LogicalType::Double, BinaryOperator::Multiply)?;
         let multiply_f64_1 = multiply_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Null);
+            .binary_eval(&DataValue::Null, &DataValue::Null)?;
         let multiply_f64_2 = multiply_evaluator
             .0
-            .binary_eval(&DataValue::Float64(OrderedFloat(1.0)), &DataValue::Null);
+            .binary_eval(&DataValue::Float64(OrderedFloat(1.0)), &DataValue::Null)?;
         let multiply_f64_3 = multiply_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Float64(OrderedFloat(1.0)));
+            .binary_eval(&DataValue::Null, &DataValue::Float64(OrderedFloat(1.0)))?;
         let multiply_f64_4 = multiply_evaluator.0.binary_eval(
             &DataValue::Float64(OrderedFloat(1.0)),
             &DataValue::Float64(OrderedFloat(1.0)),
-        );
+        )?;
 
         assert_eq!(multiply_f64_1, multiply_f64_2);
         assert_eq!(multiply_f64_2, multiply_f64_3);
@@ -646,16 +659,16 @@ mod test {
             EvaluatorFactory::binary_create(LogicalType::Integer, BinaryOperator::Divide)?;
         let divide_i32_1 = divide_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Null);
+            .binary_eval(&DataValue::Null, &DataValue::Null)?;
         let divide_i32_2 = divide_evaluator
             .0
-            .binary_eval(&DataValue::Int32(1), &DataValue::Null);
+            .binary_eval(&DataValue::Int32(1), &DataValue::Null)?;
         let divide_i32_3 = divide_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Int32(1));
+            .binary_eval(&DataValue::Null, &DataValue::Int32(1))?;
         let divide_i32_4 = divide_evaluator
             .0
-            .binary_eval(&DataValue::Int32(1), &DataValue::Int32(1));
+            .binary_eval(&DataValue::Int32(1), &DataValue::Int32(1))?;
 
         assert_eq!(divide_i32_1, divide_i32_2);
         assert_eq!(divide_i32_2, divide_i32_3);
@@ -665,16 +678,16 @@ mod test {
             EvaluatorFactory::binary_create(LogicalType::Bigint, BinaryOperator::Divide)?;
         let divide_i64_1 = divide_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Null);
+            .binary_eval(&DataValue::Null, &DataValue::Null)?;
         let divide_i64_2 = divide_evaluator
             .0
-            .binary_eval(&DataValue::Int64(1), &DataValue::Null);
+            .binary_eval(&DataValue::Int64(1), &DataValue::Null)?;
         let divide_i64_3 = divide_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Int64(1));
+            .binary_eval(&DataValue::Null, &DataValue::Int64(1))?;
         let divide_i64_4 = divide_evaluator
             .0
-            .binary_eval(&DataValue::Int64(1), &DataValue::Int64(1));
+            .binary_eval(&DataValue::Int64(1), &DataValue::Int64(1))?;
 
         assert_eq!(divide_i64_1, divide_i64_2);
         assert_eq!(divide_i64_2, divide_i64_3);
@@ -684,17 +697,17 @@ mod test {
             EvaluatorFactory::binary_create(LogicalType::Double, BinaryOperator::Divide)?;
         let divide_f64_1 = divide_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Null);
+            .binary_eval(&DataValue::Null, &DataValue::Null)?;
         let divide_f64_2 = divide_evaluator
             .0
-            .binary_eval(&DataValue::Float64(OrderedFloat(1.0)), &DataValue::Null);
+            .binary_eval(&DataValue::Float64(OrderedFloat(1.0)), &DataValue::Null)?;
         let divide_f64_3 = divide_evaluator
             .0
-            .binary_eval(&DataValue::Null, &DataValue::Float64(OrderedFloat(1.0)));
+            .binary_eval(&DataValue::Null, &DataValue::Float64(OrderedFloat(1.0)))?;
         let divide_f64_4 = divide_evaluator.0.binary_eval(
             &DataValue::Float64(OrderedFloat(1.0)),
             &DataValue::Float64(OrderedFloat(1.0)),
-        );
+        )?;
 
         assert_eq!(divide_f64_1, divide_f64_2);
         assert_eq!(divide_f64_2, divide_f64_3);
@@ -709,14 +722,14 @@ mod test {
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Int32(1), &DataValue::Int32(0),),
+                .binary_eval(&DataValue::Int32(1), &DataValue::Int32(0),)?,
             DataValue::Boolean(true)
         );
         let evaluator = EvaluatorFactory::binary_create(LogicalType::Integer, BinaryOperator::Lt)?;
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Int32(1), &DataValue::Int32(0),),
+                .binary_eval(&DataValue::Int32(1), &DataValue::Int32(0),)?,
             DataValue::Boolean(false)
         );
         let evaluator =
@@ -724,7 +737,7 @@ mod test {
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Int32(1), &DataValue::Int32(1),),
+                .binary_eval(&DataValue::Int32(1), &DataValue::Int32(1),)?,
             DataValue::Boolean(true)
         );
         let evaluator =
@@ -732,7 +745,7 @@ mod test {
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Int32(1), &DataValue::Int32(1),),
+                .binary_eval(&DataValue::Int32(1), &DataValue::Int32(1),)?,
             DataValue::Boolean(true)
         );
         let evaluator =
@@ -740,28 +753,28 @@ mod test {
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Int32(1), &DataValue::Int32(1),),
+                .binary_eval(&DataValue::Int32(1), &DataValue::Int32(1),)?,
             DataValue::Boolean(false)
         );
         let evaluator = EvaluatorFactory::binary_create(LogicalType::Integer, BinaryOperator::Eq)?;
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Int32(1), &DataValue::Int32(1),),
+                .binary_eval(&DataValue::Int32(1), &DataValue::Int32(1),)?,
             DataValue::Boolean(true)
         );
         let evaluator = EvaluatorFactory::binary_create(LogicalType::Integer, BinaryOperator::Gt)?;
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Null, &DataValue::Int32(0),),
+                .binary_eval(&DataValue::Null, &DataValue::Int32(0),)?,
             DataValue::Null
         );
         let evaluator = EvaluatorFactory::binary_create(LogicalType::Integer, BinaryOperator::Lt)?;
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Null, &DataValue::Int32(0),),
+                .binary_eval(&DataValue::Null, &DataValue::Int32(0),)?,
             DataValue::Null
         );
         let evaluator =
@@ -769,7 +782,7 @@ mod test {
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Null, &DataValue::Int32(1),),
+                .binary_eval(&DataValue::Null, &DataValue::Int32(1),)?,
             DataValue::Null
         );
         let evaluator =
@@ -777,7 +790,7 @@ mod test {
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Null, &DataValue::Int32(1),),
+                .binary_eval(&DataValue::Null, &DataValue::Int32(1),)?,
             DataValue::Null
         );
         let evaluator =
@@ -785,19 +798,21 @@ mod test {
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Null, &DataValue::Int32(1),),
+                .binary_eval(&DataValue::Null, &DataValue::Int32(1),)?,
             DataValue::Null
         );
         let evaluator = EvaluatorFactory::binary_create(LogicalType::Integer, BinaryOperator::Eq)?;
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Null, &DataValue::Int32(1),),
+                .binary_eval(&DataValue::Null, &DataValue::Int32(1),)?,
             DataValue::Null
         );
         let evaluator = EvaluatorFactory::binary_create(LogicalType::Integer, BinaryOperator::Eq)?;
         assert_eq!(
-            evaluator.0.binary_eval(&DataValue::Null, &DataValue::Null,),
+            evaluator
+                .0
+                .binary_eval(&DataValue::Null, &DataValue::Null,)?,
             DataValue::Null
         );
 
@@ -810,50 +825,50 @@ mod test {
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Boolean(true), &DataValue::Boolean(true),),
+                .binary_eval(&DataValue::Boolean(true), &DataValue::Boolean(true),)?,
             DataValue::Boolean(true)
         );
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Boolean(false), &DataValue::Boolean(true),),
+                .binary_eval(&DataValue::Boolean(false), &DataValue::Boolean(true),)?,
             DataValue::Boolean(false)
         );
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Boolean(false), &DataValue::Boolean(false),),
+                .binary_eval(&DataValue::Boolean(false), &DataValue::Boolean(false),)?,
             DataValue::Boolean(false)
         );
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Null, &DataValue::Boolean(true),),
+                .binary_eval(&DataValue::Null, &DataValue::Boolean(true),)?,
             DataValue::Null
         );
         let evaluator = EvaluatorFactory::binary_create(LogicalType::Boolean, BinaryOperator::Or)?;
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Boolean(true), &DataValue::Boolean(true),),
+                .binary_eval(&DataValue::Boolean(true), &DataValue::Boolean(true),)?,
             DataValue::Boolean(true)
         );
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Boolean(false), &DataValue::Boolean(true),),
+                .binary_eval(&DataValue::Boolean(false), &DataValue::Boolean(true),)?,
             DataValue::Boolean(true)
         );
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Boolean(false), &DataValue::Boolean(false),),
+                .binary_eval(&DataValue::Boolean(false), &DataValue::Boolean(false),)?,
             DataValue::Boolean(false)
         );
         assert_eq!(
             evaluator
                 .0
-                .binary_eval(&DataValue::Null, &DataValue::Boolean(true),),
+                .binary_eval(&DataValue::Null, &DataValue::Boolean(true),)?,
             DataValue::Boolean(true)
         );
 
@@ -878,7 +893,7 @@ mod test {
                     ty: Utf8Type::Variable(None),
                     unit: CharLengthUnits::Characters,
                 },
-            ),
+            )?,
             DataValue::Boolean(false)
         );
         let evaluator = EvaluatorFactory::binary_create(
@@ -897,7 +912,7 @@ mod test {
                     ty: Utf8Type::Variable(None),
                     unit: CharLengthUnits::Characters,
                 },
-            ),
+            )?,
             DataValue::Boolean(true)
         );
         let evaluator = EvaluatorFactory::binary_create(
@@ -916,7 +931,7 @@ mod test {
                     ty: Utf8Type::Variable(None),
                     unit: CharLengthUnits::Characters,
                 },
-            ),
+            )?,
             DataValue::Boolean(true)
         );
         let evaluator = EvaluatorFactory::binary_create(
@@ -935,7 +950,7 @@ mod test {
                     ty: Utf8Type::Variable(None),
                     unit: CharLengthUnits::Characters,
                 },
-            ),
+            )?,
             DataValue::Boolean(true)
         );
         let evaluator = EvaluatorFactory::binary_create(
@@ -954,7 +969,7 @@ mod test {
                     ty: Utf8Type::Variable(None),
                     unit: CharLengthUnits::Characters,
                 },
-            ),
+            )?,
             DataValue::Boolean(false)
         );
         let evaluator = EvaluatorFactory::binary_create(
@@ -973,7 +988,7 @@ mod test {
                     ty: Utf8Type::Variable(None),
                     unit: CharLengthUnits::Characters,
                 },
-            ),
+            )?,
             DataValue::Boolean(true)
         );
         let evaluator = EvaluatorFactory::binary_create(
@@ -988,7 +1003,7 @@ mod test {
                     ty: Utf8Type::Variable(None),
                     unit: CharLengthUnits::Characters,
                 },
-            ),
+            )?,
             DataValue::Null
         );
         let evaluator = EvaluatorFactory::binary_create(
@@ -1003,7 +1018,7 @@ mod test {
                     ty: Utf8Type::Variable(None),
                     unit: CharLengthUnits::Characters,
                 },
-            ),
+            )?,
             DataValue::Null
         );
         let evaluator = EvaluatorFactory::binary_create(
@@ -1018,7 +1033,7 @@ mod test {
                     ty: Utf8Type::Variable(None),
                     unit: CharLengthUnits::Characters,
                 },
-            ),
+            )?,
             DataValue::Null
         );
         let evaluator = EvaluatorFactory::binary_create(
@@ -1033,7 +1048,7 @@ mod test {
                     ty: Utf8Type::Variable(None),
                     unit: CharLengthUnits::Characters,
                 },
-            ),
+            )?,
             DataValue::Null
         );
         let evaluator = EvaluatorFactory::binary_create(
@@ -1048,7 +1063,7 @@ mod test {
                     ty: Utf8Type::Variable(None),
                     unit: CharLengthUnits::Characters,
                 },
-            ),
+            )?,
             DataValue::Null
         );
 
@@ -1058,155 +1073,155 @@ mod test {
     #[test]
     fn test_binary_op_time32_and_time64() -> Result<(), DatabaseError> {
         let evaluator_time32 =
-            EvaluatorFactory::binary_create(LogicalType::Time(None, false), BinaryOperator::Plus)?;
+            EvaluatorFactory::binary_create(LogicalType::Time(None), BinaryOperator::Plus)?;
         assert_eq!(
             evaluator_time32.0.binary_eval(
-                &DataValue::Time32(4190119896, 3, false),
-                &DataValue::Time32(2621204256, 4, false),
-            ),
-            DataValue::Time32(2618593017, 4, false)
+                &DataValue::Time32(4190119896, 3),
+                &DataValue::Time32(2621204256, 4),
+            )?,
+            DataValue::Time32(2618593017, 4)
         );
         assert_eq!(
             evaluator_time32.0.binary_eval(
-                &DataValue::Time32(4190175696, 3, false),
-                &DataValue::Time32(2621224256, 4, false),
-            ),
+                &DataValue::Time32(4190175696, 3),
+                &DataValue::Time32(2621224256, 4),
+            )?,
             DataValue::Null
         );
 
         let evaluator_time32 =
-            EvaluatorFactory::binary_create(LogicalType::Time(None, false), BinaryOperator::Minus)?;
+            EvaluatorFactory::binary_create(LogicalType::Time(None), BinaryOperator::Minus)?;
         assert_eq!(
             evaluator_time32.0.binary_eval(
-                &DataValue::Time32(4190119896, 3, false),
-                &DataValue::Time32(2621204256, 4, false),
-            ),
+                &DataValue::Time32(4190119896, 3),
+                &DataValue::Time32(2621204256, 4),
+            )?,
             DataValue::Null
         );
         assert_eq!(
             evaluator_time32.0.binary_eval(
-                &DataValue::Time32(2621204256, 4, false),
-                &DataValue::Time32(4190119896, 3, false),
-            ),
-            DataValue::Time32(2375496, 4, false)
+                &DataValue::Time32(2621204256, 4),
+                &DataValue::Time32(4190119896, 3),
+            )?,
+            DataValue::Time32(2375496, 4)
         );
 
         let evaluator_time32 =
-            EvaluatorFactory::binary_create(LogicalType::Time(None, false), BinaryOperator::Gt)?;
+            EvaluatorFactory::binary_create(LogicalType::Time(None), BinaryOperator::Gt)?;
         let evaluator_time64 = EvaluatorFactory::binary_create(
             LogicalType::TimeStamp(None, false),
             BinaryOperator::Gt,
         )?;
         assert_eq!(
             evaluator_time32.0.binary_eval(
-                &DataValue::Time32(2621204256, 4, false),
-                &DataValue::Time32(4190119896, 3, false),
-            ),
+                &DataValue::Time32(2621204256, 4),
+                &DataValue::Time32(4190119896, 3),
+            )?,
             DataValue::Boolean(true)
         );
         assert_eq!(
             evaluator_time32.0.binary_eval(
-                &DataValue::Time32(4190119896, 3, false),
-                &DataValue::Time32(2621204256, 4, false),
-            ),
+                &DataValue::Time32(4190119896, 3),
+                &DataValue::Time32(2621204256, 4),
+            )?,
             DataValue::Boolean(false)
         );
         assert_eq!(
             evaluator_time64.0.binary_eval(
                 &DataValue::Time64(1736055775154814, 6, false),
                 &DataValue::Time64(1738734177256, 3, false),
-            ),
+            )?,
             DataValue::Boolean(false)
         );
         assert_eq!(
             evaluator_time64.0.binary_eval(
                 &DataValue::Time64(1738734177256, 3, false),
                 &DataValue::Time64(1736055775154814, 6, false),
-            ),
+            )?,
             DataValue::Boolean(true)
         );
 
         let evaluator_time32 =
-            EvaluatorFactory::binary_create(LogicalType::Time(None, false), BinaryOperator::GtEq)?;
+            EvaluatorFactory::binary_create(LogicalType::Time(None), BinaryOperator::GtEq)?;
         let evaluator_time64 = EvaluatorFactory::binary_create(
             LogicalType::TimeStamp(None, false),
             BinaryOperator::GtEq,
         )?;
         assert_eq!(
             evaluator_time32.0.binary_eval(
-                &DataValue::Time32(2621204256, 4, false),
-                &DataValue::Time32(4190119896, 3, false),
-            ),
+                &DataValue::Time32(2621204256, 4),
+                &DataValue::Time32(4190119896, 3),
+            )?,
             DataValue::Boolean(true)
         );
         assert_eq!(
             evaluator_time32.0.binary_eval(
-                &DataValue::Time32(4190119896, 3, false),
-                &DataValue::Time32(2621204256, 4, false),
-            ),
+                &DataValue::Time32(4190119896, 3),
+                &DataValue::Time32(2621204256, 4),
+            )?,
             DataValue::Boolean(false)
         );
         assert_eq!(
             evaluator_time32.0.binary_eval(
-                &DataValue::Time32(4190119896, 3, false),
-                &DataValue::Time32(2618828760, 4, false),
-            ),
+                &DataValue::Time32(4190119896, 3),
+                &DataValue::Time32(2618828760, 4),
+            )?,
             DataValue::Boolean(true)
         );
         assert_eq!(
             evaluator_time64.0.binary_eval(
                 &DataValue::Time64(1736055775154814, 6, false),
                 &DataValue::Time64(1738734177256, 3, false),
-            ),
+            )?,
             DataValue::Boolean(false)
         );
         assert_eq!(
             evaluator_time64.0.binary_eval(
                 &DataValue::Time64(1738734177256, 3, false),
                 &DataValue::Time64(1736055775154814, 6, false),
-            ),
+            )?,
             DataValue::Boolean(true)
         );
         assert_eq!(
             evaluator_time64.0.binary_eval(
                 &DataValue::Time64(1738734177256, 3, false),
                 &DataValue::Time64(1738734177256000, 6, false),
-            ),
+            )?,
             DataValue::Boolean(true)
         );
 
         let evaluator_time32 =
-            EvaluatorFactory::binary_create(LogicalType::Time(None, false), BinaryOperator::Eq)?;
+            EvaluatorFactory::binary_create(LogicalType::Time(None), BinaryOperator::Eq)?;
         let evaluator_time64 = EvaluatorFactory::binary_create(
             LogicalType::TimeStamp(None, false),
             BinaryOperator::Eq,
         )?;
         assert_eq!(
             evaluator_time32.0.binary_eval(
-                &DataValue::Time32(4190119896, 3, false),
-                &DataValue::Time32(2621204256, 4, false),
-            ),
+                &DataValue::Time32(4190119896, 3),
+                &DataValue::Time32(2621204256, 4),
+            )?,
             DataValue::Boolean(false)
         );
         assert_eq!(
             evaluator_time32.0.binary_eval(
-                &DataValue::Time32(4190119896, 3, false),
-                &DataValue::Time32(2618828760, 4, false),
-            ),
+                &DataValue::Time32(4190119896, 3),
+                &DataValue::Time32(2618828760, 4),
+            )?,
             DataValue::Boolean(true)
         );
         assert_eq!(
             evaluator_time64.0.binary_eval(
                 &DataValue::Time64(1738734177256, 3, false),
                 &DataValue::Time64(1736055775154814, 6, false),
-            ),
+            )?,
             DataValue::Boolean(false)
         );
         assert_eq!(
             evaluator_time64.0.binary_eval(
                 &DataValue::Time64(1738734177256, 3, false),
                 &DataValue::Time64(1738734177256000, 6, false),
-            ),
+            )?,
             DataValue::Boolean(true)
         );
 

--- a/src/types/evaluator/null.rs
+++ b/src/types/evaluator/null.rs
@@ -1,3 +1,4 @@
+use crate::errors::DatabaseError;
 use crate::types::evaluator::BinaryEvaluator;
 use crate::types::evaluator::DataValue;
 use serde::{Deserialize, Serialize};
@@ -9,7 +10,7 @@ pub struct NullBinaryEvaluator;
 
 #[typetag::serde]
 impl BinaryEvaluator for NullBinaryEvaluator {
-    fn binary_eval(&self, _: &DataValue, _: &DataValue) -> DataValue {
-        DataValue::Null
+    fn binary_eval(&self, _: &DataValue, _: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(DataValue::Null)
     }
 }

--- a/src/types/evaluator/time32.rs
+++ b/src/types/evaluator/time32.rs
@@ -1,3 +1,4 @@
+use crate::errors::DatabaseError;
 use crate::types::evaluator::BinaryEvaluator;
 use crate::types::evaluator::DataValue;
 use crate::types::value::{ONE_DAY_TO_SEC, ONE_SEC_TO_NANO};
@@ -23,9 +24,9 @@ pub struct TimeNotEqBinaryEvaluator;
 
 #[typetag::serde]
 impl BinaryEvaluator for TimePlusBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
-            (DataValue::Time32(v1, p1, _), DataValue::Time32(v2, p2, ..)) => {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
+            (DataValue::Time32(v1, p1), DataValue::Time32(v2, p2, ..)) => {
                 let (mut v1, n1) = DataValue::unpack(*v1, *p1);
                 let (v2, n2) = DataValue::unpack(*v2, *p2);
                 let mut n = n1 + n2;
@@ -35,22 +36,22 @@ impl BinaryEvaluator for TimePlusBinaryEvaluator {
                 }
                 let p = if p2 > p1 { *p2 } else { *p1 };
                 if v1 + v2 > ONE_DAY_TO_SEC {
-                    return DataValue::Null;
+                    return Ok(DataValue::Null);
                 }
-                DataValue::Time32(DataValue::pack(v1 + v2, n, p), p, false)
+                DataValue::Time32(DataValue::pack(v1 + v2, n, p), p)
             }
             (DataValue::Time32(..), DataValue::Null)
             | (DataValue::Null, DataValue::Time32(..))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for TimeMinusBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
-            (DataValue::Time32(v1, p1, _), DataValue::Time32(v2, p2, ..)) => {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
+            (DataValue::Time32(v1, p1), DataValue::Time32(v2, p2, ..)) => {
                 let (mut v1, mut n1) = DataValue::unpack(*v1, *p1);
                 let (v2, n2) = DataValue::unpack(*v2, *p2);
                 while n1 < n2 {
@@ -58,24 +59,24 @@ impl BinaryEvaluator for TimeMinusBinaryEvaluator {
                     n1 += ONE_SEC_TO_NANO;
                 }
                 if v1 < v2 {
-                    return DataValue::Null;
+                    return Ok(DataValue::Null);
                 }
                 let p = if p2 > p1 { *p2 } else { *p1 };
-                DataValue::Time32(DataValue::pack(v1 - v2, n1 - n2, p), p, false)
+                DataValue::Time32(DataValue::pack(v1 - v2, n1 - n2, p), p)
             }
             (DataValue::Time32(..), DataValue::Null)
             | (DataValue::Null, DataValue::Time32(..))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 
 #[typetag::serde]
 impl BinaryEvaluator for TimeGtBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
-            (DataValue::Time32(v1, p1, _), DataValue::Time32(v2, p2, ..)) => {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
+            (DataValue::Time32(v1, p1), DataValue::Time32(v2, p2, ..)) => {
                 let (v1, n1) = DataValue::unpack(*v1, *p1);
                 let (v2, n2) = DataValue::unpack(*v2, *p2);
                 DataValue::Boolean(v1.cmp(&v2).then_with(|| n1.cmp(&n2)).is_gt())
@@ -84,14 +85,14 @@ impl BinaryEvaluator for TimeGtBinaryEvaluator {
             | (DataValue::Null, DataValue::Time32(..))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for TimeGtEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
-            (DataValue::Time32(v1, p1, _), DataValue::Time32(v2, p2, ..)) => {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
+            (DataValue::Time32(v1, p1), DataValue::Time32(v2, p2, ..)) => {
                 let (v1, n1) = DataValue::unpack(*v1, *p1);
                 let (v2, n2) = DataValue::unpack(*v2, *p2);
                 DataValue::Boolean(!v1.cmp(&v2).then_with(|| n1.cmp(&n2)).is_lt())
@@ -100,14 +101,14 @@ impl BinaryEvaluator for TimeGtEqBinaryEvaluator {
             | (DataValue::Null, DataValue::Time32(..))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for TimeLtBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
-            (DataValue::Time32(v1, p1, _), DataValue::Time32(v2, p2, ..)) => {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
+            (DataValue::Time32(v1, p1), DataValue::Time32(v2, p2, ..)) => {
                 let (v1, n1) = DataValue::unpack(*v1, *p1);
                 let (v2, n2) = DataValue::unpack(*v2, *p2);
                 DataValue::Boolean(v1.cmp(&v2).then_with(|| n1.cmp(&n2)).is_lt())
@@ -116,14 +117,14 @@ impl BinaryEvaluator for TimeLtBinaryEvaluator {
             | (DataValue::Null, DataValue::Time32(..))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for TimeLtEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
-            (DataValue::Time32(v1, p1, _), DataValue::Time32(v2, p2, ..)) => {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
+            (DataValue::Time32(v1, p1), DataValue::Time32(v2, p2, ..)) => {
                 let (v1, n1) = DataValue::unpack(*v1, *p1);
                 let (v2, n2) = DataValue::unpack(*v2, *p2);
                 DataValue::Boolean(!v1.cmp(&v2).then_with(|| n1.cmp(&n2)).is_gt())
@@ -132,14 +133,14 @@ impl BinaryEvaluator for TimeLtEqBinaryEvaluator {
             | (DataValue::Null, DataValue::Time32(..))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for TimeEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
-            (DataValue::Time32(v1, p1, _), DataValue::Time32(v2, p2, ..)) => {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
+            (DataValue::Time32(v1, p1), DataValue::Time32(v2, p2, ..)) => {
                 let (v1, n1) = DataValue::unpack(*v1, *p1);
                 let (v2, n2) = DataValue::unpack(*v2, *p2);
                 DataValue::Boolean(v1.cmp(&v2).then_with(|| n1.cmp(&n2)).is_eq())
@@ -148,14 +149,14 @@ impl BinaryEvaluator for TimeEqBinaryEvaluator {
             | (DataValue::Null, DataValue::Time32(..))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for TimeNotEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
-            (DataValue::Time32(v1, p1, _), DataValue::Time32(v2, p2, ..)) => {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
+            (DataValue::Time32(v1, p1), DataValue::Time32(v2, p2, ..)) => {
                 let (v1, n1) = DataValue::unpack(*v1, *p1);
                 let (v2, n2) = DataValue::unpack(*v2, *p2);
                 DataValue::Boolean(!v1.cmp(&v2).then_with(|| n1.cmp(&n2)).is_eq())
@@ -164,6 +165,6 @@ impl BinaryEvaluator for TimeNotEqBinaryEvaluator {
             | (DataValue::Null, DataValue::Time32(..))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }

--- a/src/types/evaluator/time32.rs
+++ b/src/types/evaluator/time32.rs
@@ -26,7 +26,7 @@ pub struct TimeNotEqBinaryEvaluator;
 impl BinaryEvaluator for TimePlusBinaryEvaluator {
     fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
         Ok(match (left, right) {
-            (DataValue::Time32(v1, p1), DataValue::Time32(v2, p2, ..)) => {
+            (DataValue::Time32(v1, p1), DataValue::Time32(v2, p2)) => {
                 let (mut v1, n1) = DataValue::unpack(*v1, *p1);
                 let (v2, n2) = DataValue::unpack(*v2, *p2);
                 let mut n = n1 + n2;

--- a/src/types/evaluator/time64.rs
+++ b/src/types/evaluator/time64.rs
@@ -1,3 +1,4 @@
+use crate::errors::DatabaseError;
 use crate::types::evaluator::BinaryEvaluator;
 use crate::types::evaluator::DataValue;
 use serde::{Deserialize, Serialize};
@@ -18,8 +19,8 @@ pub struct Time64NotEqBinaryEvaluator;
 
 #[typetag::serde]
 impl BinaryEvaluator for Time64GtBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Time64(v1, p1, _), DataValue::Time64(v2, p2, _)) => {
                 if let (Some(v1), Some(v2)) = (
                     DataValue::from_timestamp_precision(*v1, *p1),
@@ -38,13 +39,13 @@ impl BinaryEvaluator for Time64GtBinaryEvaluator {
             | (DataValue::Null, DataValue::Time64(..))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Time64GtEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Time64(v1, p1, _), DataValue::Time64(v2, p2, _)) => {
                 if let (Some(v1), Some(v2)) = (
                     DataValue::from_timestamp_precision(*v1, *p1),
@@ -63,13 +64,13 @@ impl BinaryEvaluator for Time64GtEqBinaryEvaluator {
             | (DataValue::Null, DataValue::Time64(..))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Time64LtBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Time64(v1, p1, _), DataValue::Time64(v2, p2, _)) => {
                 if let (Some(v1), Some(v2)) = (
                     DataValue::from_timestamp_precision(*v1, *p1),
@@ -88,13 +89,13 @@ impl BinaryEvaluator for Time64LtBinaryEvaluator {
             | (DataValue::Null, DataValue::Time64(..))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Time64LtEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Time64(v1, p1, _), DataValue::Time64(v2, p2, _)) => {
                 if let (Some(v1), Some(v2)) = (
                     DataValue::from_timestamp_precision(*v1, *p1),
@@ -113,13 +114,13 @@ impl BinaryEvaluator for Time64LtEqBinaryEvaluator {
             | (DataValue::Null, DataValue::Time64(..))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Time64EqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Time64(v1, p1, _), DataValue::Time64(v2, p2, _)) => {
                 if let (Some(v1), Some(v2)) = (
                     DataValue::from_timestamp_precision(*v1, *p1),
@@ -138,13 +139,13 @@ impl BinaryEvaluator for Time64EqBinaryEvaluator {
             | (DataValue::Null, DataValue::Time64(..))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Time64NotEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Time64(v1, p1, _), DataValue::Time64(v2, p2, _)) => {
                 if let (Some(v1), Some(v2)) = (
                     DataValue::from_timestamp_precision(*v1, *p1),
@@ -163,6 +164,6 @@ impl BinaryEvaluator for Time64NotEqBinaryEvaluator {
             | (DataValue::Null, DataValue::Time64(..))
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }

--- a/src/types/evaluator/tuple.rs
+++ b/src/types/evaluator/tuple.rs
@@ -1,3 +1,4 @@
+use crate::errors::DatabaseError;
 use crate::types::evaluator::BinaryEvaluator;
 use crate::types::evaluator::DataValue;
 use serde::{Deserialize, Serialize};
@@ -50,32 +51,32 @@ fn tuple_cmp(
 
 #[typetag::serde]
 impl BinaryEvaluator for TupleEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Tuple(v1, ..), DataValue::Tuple(v2, ..)) => DataValue::Boolean(*v1 == *v2),
             (DataValue::Null, DataValue::Boolean(_))
             | (DataValue::Boolean(_), DataValue::Null)
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for TupleNotEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Tuple(v1, ..), DataValue::Tuple(v2, ..)) => DataValue::Boolean(*v1 != *v2),
             (DataValue::Null, DataValue::Boolean(_))
             | (DataValue::Boolean(_), DataValue::Null)
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for TupleGtBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Tuple(v1, is_upper1), DataValue::Tuple(v2, is_upper2)) => {
                 tuple_cmp((v1, is_upper1), (v2, is_upper2))
                     .map(|order| DataValue::Boolean(order.is_gt()))
@@ -85,13 +86,13 @@ impl BinaryEvaluator for TupleGtBinaryEvaluator {
             | (DataValue::Boolean(_), DataValue::Null)
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for TupleGtEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Tuple(v1, is_upper1), DataValue::Tuple(v2, is_upper2)) => {
                 tuple_cmp((v1, is_upper1), (v2, is_upper2))
                     .map(|order| DataValue::Boolean(order.is_ge()))
@@ -101,13 +102,13 @@ impl BinaryEvaluator for TupleGtEqBinaryEvaluator {
             | (DataValue::Boolean(_), DataValue::Null)
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for TupleLtBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Tuple(v1, is_upper1), DataValue::Tuple(v2, is_upper2)) => {
                 tuple_cmp((v1, is_upper1), (v2, is_upper2))
                     .map(|order| DataValue::Boolean(order.is_lt()))
@@ -117,13 +118,13 @@ impl BinaryEvaluator for TupleLtBinaryEvaluator {
             | (DataValue::Boolean(_), DataValue::Null)
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for TupleLtEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Tuple(v1, is_upper1), DataValue::Tuple(v2, is_upper2)) => {
                 tuple_cmp((v1, is_upper1), (v2, is_upper2))
                     .map(|order| DataValue::Boolean(order.is_le()))
@@ -133,6 +134,6 @@ impl BinaryEvaluator for TupleLtEqBinaryEvaluator {
             | (DataValue::Boolean(_), DataValue::Null)
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }

--- a/src/types/evaluator/uint16.rs
+++ b/src/types/evaluator/uint16.rs
@@ -1,6 +1,7 @@
 use crate::numeric_binary_evaluator_definition;
 use crate::types::evaluator::BinaryEvaluator;
 use crate::types::evaluator::DataValue;
+use crate::types::DatabaseError;
 use paste::paste;
 use serde::{Deserialize, Serialize};
 use std::hint;

--- a/src/types/evaluator/uint32.rs
+++ b/src/types/evaluator/uint32.rs
@@ -1,6 +1,7 @@
 use crate::numeric_binary_evaluator_definition;
 use crate::types::evaluator::BinaryEvaluator;
 use crate::types::evaluator::DataValue;
+use crate::types::DatabaseError;
 use paste::paste;
 use serde::{Deserialize, Serialize};
 use std::hint;

--- a/src/types/evaluator/uint64.rs
+++ b/src/types/evaluator/uint64.rs
@@ -1,6 +1,7 @@
 use crate::numeric_binary_evaluator_definition;
 use crate::types::evaluator::BinaryEvaluator;
 use crate::types::evaluator::DataValue;
+use crate::types::DatabaseError;
 use paste::paste;
 use serde::{Deserialize, Serialize};
 use std::hint;

--- a/src/types/evaluator/uint8.rs
+++ b/src/types/evaluator/uint8.rs
@@ -1,6 +1,7 @@
 use crate::numeric_binary_evaluator_definition;
 use crate::types::evaluator::BinaryEvaluator;
 use crate::types::evaluator::DataValue;
+use crate::types::DatabaseError;
 use paste::paste;
 use serde::{Deserialize, Serialize};
 use std::hint;

--- a/src/types/evaluator/utf8.rs
+++ b/src/types/evaluator/utf8.rs
@@ -1,3 +1,4 @@
+use crate::errors::DatabaseError;
 use crate::types::evaluator::BinaryEvaluator;
 use crate::types::evaluator::DataValue;
 use crate::types::value::Utf8Type;
@@ -31,8 +32,8 @@ pub struct Utf8NotLikeBinaryEvaluator {
 
 #[typetag::serde]
 impl BinaryEvaluator for Utf8GtBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Utf8 { value: v1, .. }, DataValue::Utf8 { value: v2, .. }) => {
                 DataValue::Boolean(v1 > v2)
             }
@@ -40,13 +41,13 @@ impl BinaryEvaluator for Utf8GtBinaryEvaluator {
             | (DataValue::Null, DataValue::Utf8 { .. })
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Utf8GtEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Utf8 { value: v1, .. }, DataValue::Utf8 { value: v2, .. }) => {
                 DataValue::Boolean(v1 >= v2)
             }
@@ -54,13 +55,13 @@ impl BinaryEvaluator for Utf8GtEqBinaryEvaluator {
             | (DataValue::Null, DataValue::Utf8 { .. })
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Utf8LtBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Utf8 { value: v1, .. }, DataValue::Utf8 { value: v2, .. }) => {
                 DataValue::Boolean(v1 < v2)
             }
@@ -68,13 +69,13 @@ impl BinaryEvaluator for Utf8LtBinaryEvaluator {
             | (DataValue::Null, DataValue::Utf8 { .. })
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Utf8LtEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Utf8 { value: v1, .. }, DataValue::Utf8 { value: v2, .. }) => {
                 DataValue::Boolean(v1 <= v2)
             }
@@ -82,13 +83,13 @@ impl BinaryEvaluator for Utf8LtEqBinaryEvaluator {
             | (DataValue::Null, DataValue::Utf8 { .. })
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Utf8EqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Utf8 { value: v1, .. }, DataValue::Utf8 { value: v2, .. }) => {
                 DataValue::Boolean(v1 == v2)
             }
@@ -96,13 +97,13 @@ impl BinaryEvaluator for Utf8EqBinaryEvaluator {
             | (DataValue::Null, DataValue::Utf8 { .. })
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Utf8NotEqBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Utf8 { value: v1, .. }, DataValue::Utf8 { value: v2, .. }) => {
                 DataValue::Boolean(v1 != v2)
             }
@@ -110,13 +111,13 @@ impl BinaryEvaluator for Utf8NotEqBinaryEvaluator {
             | (DataValue::Null, DataValue::Utf8 { .. })
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Utf8StringConcatBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Utf8 { value: v1, .. }, DataValue::Utf8 { value: v2, .. }) => {
                 DataValue::Utf8 {
                     value: v1.clone() + v2,
@@ -128,13 +129,13 @@ impl BinaryEvaluator for Utf8StringConcatBinaryEvaluator {
             | (DataValue::Null, DataValue::Utf8 { .. })
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Utf8LikeBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Utf8 { value, .. }, DataValue::Utf8 { value: pattern, .. }) => {
                 DataValue::Boolean(string_like(value, pattern, self.escape_char))
             }
@@ -142,13 +143,13 @@ impl BinaryEvaluator for Utf8LikeBinaryEvaluator {
             | (DataValue::Null, DataValue::Utf8 { .. })
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 #[typetag::serde]
 impl BinaryEvaluator for Utf8NotLikeBinaryEvaluator {
-    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue {
-        match (left, right) {
+    fn binary_eval(&self, left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
+        Ok(match (left, right) {
             (DataValue::Utf8 { value, .. }, DataValue::Utf8 { value: pattern, .. }) => {
                 DataValue::Boolean(!string_like(value, pattern, self.escape_char))
             }
@@ -156,7 +157,7 @@ impl BinaryEvaluator for Utf8NotLikeBinaryEvaluator {
             | (DataValue::Null, DataValue::Utf8 { .. })
             | (DataValue::Null, DataValue::Null) => DataValue::Null,
             _ => unsafe { hint::unreachable_unchecked() },
-        }
+        })
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -48,7 +48,7 @@ pub enum LogicalType {
     Varchar(Option<u32>, CharLengthUnits),
     Date,
     DateTime,
-    Time(Option<u64>, bool),
+    Time(Option<u64>),
     TimeStamp(Option<u64>, bool),
     // decimal (precision, scale)
     Decimal(Option<u8>, Option<u8>),
@@ -84,7 +84,7 @@ impl LogicalType {
         } else if type_id == TypeId::of::<NaiveDateTime>() {
             Some(LogicalType::DateTime)
         } else if type_id == TypeId::of::<NaiveTime>() {
-            Some(LogicalType::Time(Some(0), false))
+            Some(LogicalType::Time(Some(0)))
         } else if type_id == TypeId::of::<Decimal>() {
             Some(LogicalType::Decimal(None, None))
         } else if type_id == TypeId::of::<String>() {
@@ -117,7 +117,7 @@ impl LogicalType {
             LogicalType::Decimal(_, _) => Some(16),
             LogicalType::Date => Some(4),
             LogicalType::DateTime => Some(8),
-            LogicalType::Time(_, _) => Some(4),
+            LogicalType::Time(_) => Some(4),
             LogicalType::TimeStamp(_, _) => Some(8),
             LogicalType::Tuple(_) => unreachable!(),
         }
@@ -447,7 +447,7 @@ impl TryFrom<sqlparser::ast::DataType> for LogicalType {
                         "time's zone is not supported".to_string(),
                     ));
                 }
-                Ok(LogicalType::Time(precision, false))
+                Ok(LogicalType::Time(precision))
             }
             sqlparser::ast::DataType::Timestamp(precision, info) => {
                 let mut zone = false;
@@ -502,7 +502,7 @@ impl std::fmt::Display for LogicalType {
             LogicalType::TimeStamp(precision, zone) => {
                 write!(f, "TimeStamp({:?}, {:?})", precision, zone)?
             }
-            LogicalType::Time(precision, zone) => write!(f, "Time({:?}, {:?})", precision, zone)?,
+            LogicalType::Time(precision) => write!(f, "Time({:?})", precision)?,
             LogicalType::Decimal(precision, scale) => {
                 write!(f, "Decimal({:?}, {:?})", precision, scale)?
             }
@@ -602,23 +602,9 @@ pub(crate) mod test {
         fn_assert(
             &mut cursor,
             &mut reference_tables,
-            LogicalType::Time(Some(3), true),
+            LogicalType::Time(Some(3)),
         )?;
-        fn_assert(
-            &mut cursor,
-            &mut reference_tables,
-            LogicalType::Time(Some(3), false),
-        )?;
-        fn_assert(
-            &mut cursor,
-            &mut reference_tables,
-            LogicalType::Time(None, true),
-        )?;
-        fn_assert(
-            &mut cursor,
-            &mut reference_tables,
-            LogicalType::Time(None, false),
-        )?;
+        fn_assert(&mut cursor, &mut reference_tables, LogicalType::Time(None))?;
         fn_assert(
             &mut cursor,
             &mut reference_tables,

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -81,9 +81,7 @@ mod test {
     }
 
     scala_function!(MyScalaFunction::SUM(LogicalType::Integer, LogicalType::Integer) -> LogicalType::Integer => (|v1: DataValue, v2: DataValue| {
-        let plus_evaluator = EvaluatorFactory::binary_create(LogicalType::Integer, BinaryOperator::Plus)?;
-
-        Ok(plus_evaluator.0.binary_eval(&v1, &v2))
+        EvaluatorFactory::binary_create(LogicalType::Integer, BinaryOperator::Plus)?.binary_eval(&v1, &v2)
     }));
 
     table_function!(MyTableFunction::TEST_NUMBERS(LogicalType::Integer) -> [c1: LogicalType::Integer, c2: LogicalType::Integer] => (|v1: DataValue| {

--- a/tests/slt/crdb/where.slt
+++ b/tests/slt/crdb/where.slt
@@ -1,0 +1,111 @@
+control sortmode rowsort
+
+statement ok
+drop table if exists kv
+
+statement ok
+CREATE TABLE kv (k INT PRIMARY KEY,  v INT)
+
+statement ok
+INSERT INTO kv VALUES (1, 2), (3, 4), (5, 6), (7, 8)
+
+statement ok
+drop table if exists kvString
+
+statement ok
+CREATE TABLE kvString (k STRING PRIMARY KEY,  v STRING)
+
+statement ok
+INSERT INTO kvString VALUES ('like1', 'hell%'), ('like2', 'worl%')
+
+query II
+SELECT * FROM kv WHERE True
+----
+1 2
+3 4
+5 6
+7 8
+
+statement ok
+SELECT * FROM kv WHERE False
+
+query II
+SELECT * FROM kv WHERE k IN (1, 3)
+----
+1 2
+3 4
+
+query II
+SELECT * FROM kv WHERE v IN (6)
+----
+5 6
+
+query II
+SELECT * FROM kv WHERE k IN (SELECT k FROM kv)
+----
+1 2
+3 4
+5 6
+7 8
+
+statement error 1065
+SELECT * FROM kv WHERE (k,v) IN (SELECT * FROM kv)
+
+query II
+SELECT * FROM kv WHERE k IN (SELECT k FROM kv)
+----
+1 2
+3 4
+5 6
+7 8
+
+statement error
+SELECT * FROM kv WHERE nonexistent = 1
+
+query B
+SELECT 'hello' LIKE v FROM kvString WHERE k LIKE 'like%' ORDER BY k
+----
+false
+true
+
+query II
+SELECT * FROM kv WHERE k IN (1, 5.0, 9)
+----
+1 2
+5 6
+
+statement ok
+drop table if exists ab
+
+statement ok
+CREATE TABLE ab (pk int primary key,a INT NULL, b INT NULL)
+
+statement ok
+INSERT INTO ab VALUES (0, 1, 10), (1, 2, 20), (2, 3, 30), (3, 4, NULL), (4, NULL, 50), (5, NULL, NULL)
+
+query II
+SELECT a, b FROM ab WHERE a IN (1, 3, 4)
+----
+1 10
+3 30
+4 null
+
+query II
+SELECT a, b FROM ab WHERE a IN (1, 3, 4, NULL)
+----
+1 10
+3 30
+4 null
+
+query
+SELECT a, b FROM ab WHERE (a, b) IN ((1, 10), (3, 30), (4, 40))
+----
+1 10
+3 30
+
+query
+SELECT a, b FROM ab WHERE (a, b) IN ((1, 10), (4, NULL), (NULL, 50))
+----
+1 10
+4 null
+null 50


### PR DESCRIPTION
### What problem does this PR solve?

- add e2e test: "crdb/where.slt"
- `RangeDetacher::detach` will check the type of range and convert it
- fixed range extraction when using `In` expression
- `DataValue::Time` removes the zone
- in subquery supports tuple output

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
